### PR TITLE
xrootd4j: remove '?' prefix when building opaque string

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
@@ -504,8 +504,7 @@ public class XrootdTpcInfo {
                 external.put(entry.getKey(), entry.getValue());
             }
         }
-        this.external = OpaqueStringParser.buildOpaqueString(external)
-                                          .substring(1);  // remove '?'
+        this.external = OpaqueStringParser.buildOpaqueString(external);
     }
 
     private void setSourceFromOpaque(Map<String, String> map)

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/OpaqueStringParser.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/OpaqueStringParser.java
@@ -140,9 +140,8 @@ public class OpaqueStringParser {
      */
     public static String buildOpaqueString(Map<String, String> map)
     {
-        return OPAQUE_STRING_PREFIX
-                        + Joiner.on(OPAQUE_PREFIX)
-                                .withKeyValueSeparator("" + OPAQUE_SEPARATOR)
-                                .join(map);
+        return Joiner.on(OPAQUE_PREFIX)
+                     .withKeyValueSeparator("" + OPAQUE_SEPARATOR)
+                     .join(map);
     }
 }


### PR DESCRIPTION
Motivation:

Opaque information is transmitted between client and service
by appending a query to the URL.

Originally, dCache only added the UUID as opaque info in order
for the client to find the correct mover when redirected to the
pool.  With the advent of tpc support, more opaque info needs
to pass between the client and the two server endpoints.

A misunderstanding caused me to prefix the query token '?'
to the string when constructing it from its parts.  While
later clients seemed to be robust enough to ignore this,
the earlier clients (e.g., 3.2.4) have trouble with it
and the operation fails.

Note also that the code was uncertain about the need for
this prefix as it was necessary to eliminate it when
processing TPC data into the TpcInfo object!

Modification:

Remove the '?', and also the TpcInfo method hack.

Result:

Two-party works again with earlier clients, while
all operations work with the current v4.8 clients.

Target: master
Request: 3.3
Acked-by: Dmitry