### PR TITLE
use "DHNP" KeyAgreement that invokes KeyAgreementSpi that does not

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/DHSession.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/DHSession.java
@@ -112,7 +112,13 @@ public class DHSession
                         KeyPairGenerator.getInstance(DH_ALGORITHM_NAME, "BC");
         kpairGen.initialize(_dhParameterSpec);
         _localDHKeyPair = kpairGen.generateKeyPair();
-        _keyAgreement = KeyAgreement.getInstance(DH_ALGORITHM_NAME, "BC");
+        try {
+            // TODO: the DHNP needs to be removed at some point
+            // when xrdcp switches to padded version of DH_compute_key
+            _keyAgreement = KeyAgreement.getInstance("DHNP", "BC");
+        } catch (NoSuchAlgorithmException nsae) {
+            _keyAgreement = KeyAgreement.getInstance(DH_ALGORITHM_NAME, "BC");
+        }
         _keyAgreement.init(_localDHKeyPair.getPrivate());
     }
 


### PR DESCRIPTION
pad bytes on key exchange. If this algorithm is not found there
is fallback to standard "DH" algorithm (this way this will work
against modified and unmodified BC jar)
