### PR TITLE
DHSession: retry using KeyAgreement.generateSecret("TlsPremasterSecret")

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/DHSession.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/DHSession.java
@@ -257,7 +257,9 @@ public class DHSession
         Cipher cipher = Cipher.getInstance(cipherSpec,
                                            "BC");
         /* need a 128-bit key, that's the way to get it */
-        SecretKey sessionKey = new SecretKeySpec(_keyAgreement.generateSecret(),
+        SecretKey sessionKey = new SecretKeySpec(_keyAgreement
+                                                 .generateSecret("TlsPremasterSecret")
+                                                 .getEncoded(),
                                                  0,
                                                  blocksize,
                                                  keySpec);

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/DHSession.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/DHSession.java
@@ -226,19 +226,36 @@ public class DHSession
     {
         byte [] iv = new byte[blocksize];
         Arrays.fill(iv, (byte)0);
-        final byte[] sharedSecret = _keyAgreement.generateSecret();
-        /* need a 128-bit key, that's the way to get it */
-        SecretKey sessionKey = new SecretKeySpec(sharedSecret,
-                                                 0,
-                                                 blocksize,
-                                                 keySpec);
         IvParameterSpec paramSpec = new IvParameterSpec(iv);
-
         Cipher cipher = Cipher.getInstance(cipherSpec,
                                            "BC");
-        cipher.init(mode, sessionKey, paramSpec);
-
-        return cipher.doFinal(buffer);
+        byte[] output;
+        SecretKey sessionKey;
+        /**
+         * This try / catch construct is used to handle
+         * xrootd clients that do not use padded version of DH_compute_key
+         * Once they switched to DH_compute_key_padded this will no longer
+         * be neeeded.
+         */
+        try {
+            /* need a 128-bit key, that's the way to get it */
+            sessionKey = new SecretKeySpec(_keyAgreement.generateSecret(),
+                                           0,
+                                           blocksize,
+                                           keySpec);
+            cipher.init(mode, sessionKey, paramSpec);
+            output = cipher.doFinal(buffer);
+        } catch (BadPaddingException e) {
+            sessionKey = new SecretKeySpec(_keyAgreement
+                                           .generateSecret("TlsPremasterSecret")
+                                           .getEncoded(),
+                                           0,
+                                           blocksize,
+                                           keySpec);
+            cipher.init(mode, sessionKey, paramSpec);
+            output = cipher.doFinal(buffer);
+        }
+        return output;
     }
 
     /**

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/DHSession.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/DHSession.java
@@ -233,38 +233,24 @@ public class DHSession
                     BadPaddingException, InvalidAlgorithmParameterException,
                     NoSuchProviderException
     {
-        return translate(cipherSpec,
-                         keySpec,
-                         blocksize,
-                         unencrypted,
-                         Cipher.ENCRYPT_MODE);
-    }
-
-    private byte[] translate(String cipherSpec,
-                             String keySpec,
-                             int blocksize,
-                             byte[] buffer,
-                             int mode)
-                    throws InvalidKeyException,
-                    IllegalStateException, NoSuchAlgorithmException,
-                    NoSuchPaddingException, IllegalBlockSizeException,
-                    BadPaddingException, InvalidAlgorithmParameterException,
-                    NoSuchProviderException
-    {
         byte [] iv = new byte[blocksize];
         Arrays.fill(iv, (byte)0);
         IvParameterSpec paramSpec = new IvParameterSpec(iv);
         Cipher cipher = Cipher.getInstance(cipherSpec,
                                            "BC");
-        /* need a 128-bit key, that's the way to get it */
+        /**
+         * Unlike decrypt, the encrypt method always has use
+         * .generateSecret("TlsPremasterSecret") to be compatible
+         * with SLAC server (e.g. for TPC)
+         */
         SecretKey sessionKey = new SecretKeySpec(_keyAgreement
                                                  .generateSecret("TlsPremasterSecret")
                                                  .getEncoded(),
                                                  0,
                                                  blocksize,
                                                  keySpec);
-        cipher.init(mode, sessionKey, paramSpec);
-        return cipher.doFinal(buffer);
+        cipher.init(Cipher.ENCRYPT_MODE, sessionKey, paramSpec);
+        return cipher.doFinal(unencrypted);
     }
 
     /**


### PR DESCRIPTION
           if failed to to decrypt using KeyAgreement.generateSecret()
           due to added 0 padding.

Ticket: http://rt.dcache.org/Ticket/Display.html?id=9129
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9218
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9444
Issue: https://github.com/dCache/xrootd4j/issues/6.

Target: trunk