### PR TITLE
protocol: add code to identify target of kXR_stat request

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/StatRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/StatRequest.java
@@ -25,6 +25,23 @@ import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_vfs;
 
 public class StatRequest extends PathRequest
 {
+    /**
+     * How the client is specifying about which file the server should provided
+     * metadata.
+     */
+    public enum Target
+    {
+        /**
+         * The file is described by its path.
+         */
+        PATH,
+
+        /**
+         * The file is described by a file handle.
+         */
+        FHANDLE;
+    }
+
     private final short options;
     private final int fhandle;
 
@@ -40,11 +57,35 @@ public class StatRequest extends PathRequest
         return (options & kXR_vfs) == kXR_vfs;
     }
 
-    public int getFhandle() { return fhandle; }
+    public int getFhandle()
+    {
+        return fhandle;
+    }
 
     private short getOptions()
     {
         return options;
+    }
+
+    /**
+     * Provide the target type of the kXR_stat request.  The protocol allows
+     * the client to request information about a file by specifying that file's
+     * path, or by specifying an opened file handle.
+     * <p>
+     * If this method returns {@literal Target.FHANDLE} then {@link #getFhandle}
+     * describes the file handle the client is targeting.  If the returned
+     * value is {@literal Target.PATH} then {@link #getPath} describes the file
+     * path the client is targeting.
+     * @return the kind of object the client is requesting
+     */
+    public Target getTarget()
+    {
+        /**
+         * Although not documented (see https://github.com/xrootd/xrootd/issues/839 ),
+         * the SLAC xrootd server seems to make the decision based on whether
+         * plen is zero.
+         */
+        return getPath().isEmpty() ? Target.FHANDLE : Target.PATH;
     }
 
     @Override

--- a/xrootd4j/src/test/java/org/dcache/xrootd/protocol/messages/StatRequestTest.java
+++ b/xrootd4j/src/test/java/org/dcache/xrootd/protocol/messages/StatRequestTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (C) 2018 dCache.org <support@dcache.org>
+ *
+ * This file is part of xrootd4j.
+ *
+ * xrootd4j is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * xrootd4j is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with xrootd4j.  If not, see http://www.gnu.org/licenses/.
+ */
+package org.dcache.xrootd.protocol.messages;
+
+import io.netty.buffer.ByteBuf;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+
+import static io.netty.buffer.Unpooled.buffer;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public class StatRequestTest
+{
+    private ByteBuf encoded;
+    private StatRequest decoded;
+
+    @Test
+    public void shouldDecodeEmptyPath()
+    {
+        given(encodedRequest()
+                .withShort(1)    // streamid
+                .withShort(3017) // kXR_stat
+                .withByte(0)     // opts
+                .withZeros(11)   // reserved
+                .withInt(2)      // fhandle
+                .withInt(0));    // plen
+
+        whenDecoded();
+
+        assertThat(decoded.getStreamId(), is(equalTo(1)));
+        assertThat(decoded.getTarget(), is(equalTo(StatRequest.Target.FHANDLE)));
+        assertThat(decoded.getFhandle(), is(equalTo(2)));
+        assertThat(decoded.getPath(), isEmptyString());
+        assertThat(decoded.getOpaque(), isEmptyString());
+    }
+
+    @Test
+    public void shouldDecodeWithPath()
+    {
+        given(encodedRequest()
+                .withShort(1)    // streamid
+                .withShort(3017) // kXR_stat
+                .withByte(0)     // opts
+                .withZeros(11)   // reserved
+                .withInt(2)      // fhandle
+                .withInt(11)     // plen
+                .withString("my-file.dat", US_ASCII));
+
+        whenDecoded();
+
+        assertThat(decoded.getStreamId(), is(equalTo(1)));
+        assertThat(decoded.getTarget(), is(equalTo(StatRequest.Target.PATH)));
+        assertThat(decoded.getFhandle(), is(equalTo(2)));
+        assertThat(decoded.getPath(), is(equalTo("my-file.dat")));
+        assertThat(decoded.getOpaque(), isEmptyString());
+    }
+
+    private void given(ByteBufBuilder builder)
+    {
+        encoded = builder.build();
+    }
+
+    private void whenDecoded()
+    {
+        decoded = new StatRequest(encoded);
+    }
+
+    private ByteBufBuilder encodedRequest()
+    {
+        return new ByteBufBuilder();
+    }
+
+    private class ByteBufBuilder
+    {
+        private final ByteBuf buffer = buffer();
+
+        public ByteBufBuilder withString(String value, Charset charset)
+        {
+            buffer.writeCharSequence(value, charset);
+            return this;
+        }
+
+        public ByteBufBuilder withInt(int value)
+        {
+            buffer.writeInt(value);
+            return this;
+        }
+
+        public ByteBufBuilder withShort(int value)
+        {
+            buffer.writeShort(value);
+            return this;
+        }
+
+        public ByteBufBuilder withByte(int value)
+        {
+            buffer.writeByte(value);
+            return this;
+        }
+
+        public ByteBufBuilder withZeros(int count)
+        {
+            buffer.writeZero(count);
+            return this;
+        }
+
+        public ByteBuf build()
+        {
+            return buffer;
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

The kXR_stat request may target a file by path or by (open) file handle.
Although these values are exposed, the logic that describes which target
is used is missing.

Modification:

Add support to describe which target is valid.

Result:

Code using xrootd4j may discover how the client is describing which file
to stat.

Target: master
Request: 3.3
Patch: https://rb.dcache.org/r/11235/
Acked-by: Vincent Garonne