### PR TITLE
xrootd4j: do not catch Exception in request handler error routine

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientRequestHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientRequestHandler.java
@@ -89,12 +89,12 @@ public abstract class AbstractClientRequestHandler extends
         } else if (t instanceof IOException) {
             LOGGER.error("IOException caught on channel {}: {}.",
                          ctx.channel().id(), t.toString());
-        } else if (t instanceof Exception) {
+        } else if (t instanceof XrootdException) {
             LOGGER.error("Exception caught on channel {}: {}.",
                          ctx.channel().id(),
                          t.toString());
         } else {
-            LOGGER.error("Throwable caught on channel {}: {}",
+            LOGGER.error("Exception caught on channel {}: {}",
                          ctx.channel().id(),
                          t.getMessage());
             Thread me = Thread.currentThread();


### PR DESCRIPTION
Motivation:

Obvious oversight exchanged XrootdException for Exception
in a try clause.  This masks runtime errors.

Modification:

Fix it.

Result:

Correct exception handling.

Target: master
Request: 3.3
Acked-by: Paul