### PR TITLE
xrootd4j: distinguish correctly between kXR_wait and kXR_waitresp

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationHandler.java
@@ -64,8 +64,8 @@ import org.dcache.xrootd.tpc.protocol.messages.OutboundAuthenticationRequest;
 
 import static io.netty.channel.ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE;
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.dcache.xrootd.plugins.authn.gsi.BaseGSIAuthenticationHandler.PROTOCOL_VERSION;
 import static org.dcache.xrootd.plugins.authn.gsi.BaseGSIAuthenticationHandler.*;
+import static org.dcache.xrootd.plugins.authn.gsi.BaseGSIAuthenticationHandler.PROTOCOL_VERSION;
 import static org.dcache.xrootd.plugins.authn.gsi.GSIAuthenticationHandler.CRYPTO_MODE;
 import static org.dcache.xrootd.plugins.authn.gsi.GSIAuthenticationHandler.PROTOCOL;
 import static org.dcache.xrootd.protocol.XrootdProtocol.*;
@@ -471,20 +471,16 @@ public class GSIClientAuthenticationHandler extends
     {
         switch (response.getRequestId()) {
             case kXR_auth:
-                client.getExecutor().schedule(new Runnable() {
-                                                  @Override
-                                                  public void run() {
-                                                      try {
-                                                          sendAuthenticationRequest(ctx);
-                                                      } catch (XrootdException e) {
-                                                          exceptionCaught(ctx, e);
-                                                      }
-                                                  }
-                                              }, getWaitInSeconds(response),
-                                              TimeUnit.SECONDS);
+                client.getExecutor().schedule(() -> {
+                    try {
+                        sendAuthenticationRequest(ctx);
+                    } catch (XrootdException e) {
+                        exceptionCaught(ctx, e);
+                    }
+                }, getWaitInSeconds(response), TimeUnit.SECONDS);
                 break;
             default:
-                ctx.fireChannelRead(response);
+                super.doOnWaitResponse(ctx, response);
         }
     }
 

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientSourceHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientSourceHandler.java
@@ -214,22 +214,14 @@ public abstract class AbstractClientSourceHandler extends
     {
         switch (response.getRequestId()) {
             case kXR_open:
-                client.getExecutor().schedule(new Runnable() {
-                                                  @Override
-                                                  public void run() {
-                                                      sendOpenRequest(ctx);
-                                                  }
-                                              }, getWaitInSeconds(response),
-                                              TimeUnit.SECONDS);
+                client.getExecutor().schedule(() -> {
+                    sendOpenRequest(ctx);
+                }, getWaitInSeconds(response), TimeUnit.SECONDS);
                 break;
             case kXR_close:
-                client.getExecutor().schedule(new Runnable() {
-                                                  @Override
-                                                  public void run() {
-                                                      client.doClose(ctx);
-                                                  }
-                                              }, getWaitInSeconds(response),
-                                              TimeUnit.SECONDS);
+                client.getExecutor().schedule(() -> {
+                    client.doClose(ctx);
+                }, getWaitInSeconds(response), TimeUnit.SECONDS);
                 break;
             default:
                 super.doOnWaitResponse(ctx, response);

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcClientConnectHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcClientConnectHandler.java
@@ -138,22 +138,14 @@ public class TpcClientConnectHandler extends
     {
         switch (response.getRequestId()) {
             case kXR_login:
-                client.getExecutor().schedule(new Runnable() {
-                                                  @Override
-                                                  public void run() {
-                                                      sendLoginRequest(ctx);
-                                                  }
-                                              }, getWaitInSeconds(response),
-                                              TimeUnit.SECONDS);
+                client.getExecutor().schedule(() -> {
+                    sendLoginRequest(ctx);
+                }, getWaitInSeconds(response), TimeUnit.SECONDS);
                 break;
             case kXR_protocol:
-                client.getExecutor().schedule(new Runnable() {
-                                                  @Override
-                                                  public void run() {
-                                                      sendProtocolRequest(ctx);
-                                                  }
-                                              }, getWaitInSeconds(response),
-                                              TimeUnit.SECONDS);
+                client.getExecutor().schedule(() -> {
+                    sendProtocolRequest(ctx);
+                }, getWaitInSeconds(response), TimeUnit.SECONDS);
                 break;
             default:
                 super.doOnWaitResponse(ctx, response);

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSourceReadHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSourceReadHandler.java
@@ -183,22 +183,14 @@ public abstract class TpcSourceReadHandler extends AbstractClientSourceHandler
     {
         switch (response.getRequestId()) {
             case kXR_read:
-                client.getExecutor().schedule(new Runnable() {
-                                                  @Override
-                                                  public void run() {
-                                                      sendReadRequest(ctx);
-                                                  }
-                                              }, getWaitInSeconds(response),
-                                              TimeUnit.SECONDS);
+                client.getExecutor().schedule(() -> {
+                    sendReadRequest(ctx);
+                }, getWaitInSeconds(response), TimeUnit.SECONDS);
                 break;
             case kXR_query:
-                client.getExecutor().schedule(new Runnable() {
-                                                  @Override
-                                                  public void run() {
-                                                      sendChecksumRequest(ctx);
-                                                  }
-                                              }, getWaitInSeconds(response),
-                                              TimeUnit.SECONDS);
+                client.getExecutor().schedule(() -> {
+                    sendChecksumRequest(ctx);
+                }, getWaitInSeconds(response), TimeUnit.SECONDS);
                 break;
             default:
                 super.doOnWaitResponse(ctx, response);

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/core/XrootdClientDecoder.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/core/XrootdClientDecoder.java
@@ -41,6 +41,7 @@ import org.dcache.xrootd.tpc.protocol.messages.InboundOpenReadOnlyResponse;
 import org.dcache.xrootd.tpc.protocol.messages.InboundProtocolResponse;
 import org.dcache.xrootd.tpc.protocol.messages.InboundReadResponse;
 import org.dcache.xrootd.tpc.protocol.messages.InboundRedirectResponse;
+import org.dcache.xrootd.tpc.protocol.messages.InboundWaitRespResponse;
 import org.dcache.xrootd.tpc.protocol.messages.InboundWaitResponse;
 import org.dcache.xrootd.tpc.protocol.messages.XrootdInboundResponse;
 import org.dcache.xrootd.util.ParseException;
@@ -107,10 +108,15 @@ public class XrootdClientDecoder extends ByteToMessageDecoder
                                 sourceUrn, id);
                     out.add(new InboundErrorResponse(frame));
                     return;
-                case kXR_waitresp:
+                case kXR_wait:
                     LOGGER.trace("Decoder {}, channel {}: adding wait response.",
-                                sourceUrn, id);
+                                 sourceUrn, id);
                     out.add(new InboundWaitResponse(frame, requestId));
+                    return;
+                case kXR_waitresp:
+                    LOGGER.trace("Decoder {}, channel {}: adding waitresp response.",
+                                sourceUrn, id);
+                    out.add(new InboundWaitRespResponse(frame, requestId));
                     return;
                 case kXR_redirect:
                     LOGGER.trace("Decoder {}, channel {}: adding redirect response.",

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/AbstractInboundWaitResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/AbstractInboundWaitResponse.java
@@ -24,8 +24,23 @@ import io.netty.buffer.ByteBuf;
  * <p>Server's prerogative to tell the client to wait up to a
  * certain number of seconds.</p>
  */
-public class InboundWaitResponse extends AbstractInboundWaitResponse{
-    public InboundWaitResponse(ByteBuf buffer, int requestId) {
-        super(buffer, requestId);
+public class AbstractInboundWaitResponse extends AbstractXrootdInboundResponse {
+    private int maxWaitInSeconds;
+    private int nextRequest;
+
+    public AbstractInboundWaitResponse(ByteBuf buffer, int requestId)
+    {
+        super(buffer);
+        nextRequest = requestId;
+        maxWaitInSeconds = buffer.getInt(8);
+    }
+
+    public int getMaxWaitInSeconds() {
+        return maxWaitInSeconds;
+    }
+
+    @Override
+    public int getRequestId() {
+        return nextRequest;
     }
 }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundWaitRespResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundWaitRespResponse.java
@@ -22,10 +22,11 @@ import io.netty.buffer.ByteBuf;
 
 /**
  * <p>Server's prerogative to tell the client to wait up to a
- * certain number of seconds.</p>
+ * certain number of seconds.  This response also indicates
+ * the client should wait for instructions from the server.</p>
  */
-public class InboundWaitResponse extends AbstractInboundWaitResponse{
-    public InboundWaitResponse(ByteBuf buffer, int requestId) {
+public class InboundWaitRespResponse extends AbstractInboundWaitResponse {
+    public InboundWaitRespResponse(ByteBuf buffer, int requestId) {
         super(buffer, requestId);
     }
 }


### PR DESCRIPTION
Motivation:

The xrootd protocol specifies that the server can respond to the client
with instructions to wait.  There are two such responses, 4005 and 4006;
the former simply means wait, then retry.  The latter, however, means
wait for an asynchronous "go ahead" from the server.  In this case,
arriving at the max timeout with no instruction from the server
constitutes a failure, and should not trigger a retry of the
request which was checked by the wait.

Unfortunately, these two distinct instructions from the server
are currently garbled in the TPC handlers.  In particular,
the client, upon receiving 4006, waits for ten seconds, then
retries.  This provokes a "duplicate request" failure on the
server side.

Modification:

Handle 4005 as before, but distinguish this from 4006 by
timing out and failing.  The code to act on the server's
asynchronous 'attention' response (kXR_attn) is already
in place.

Result:

Duplicate request failures no longer occur.

Target: master
Request: 3.3
Acked-by: Tigran