### PR TITLE
xrootd4j-gsi: handle correctly IO/Security exceptions on credential l…

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationFactory.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationFactory.java
@@ -120,7 +120,7 @@ public class GSIClientAuthenticationFactory extends BaseGSIAuthenticationFactory
                 LOGGER.info("Refreshing proxy credential. Current refresh interval: {} ms",
                             proxyRefreshInterval);
 
-                if (Strings.isNullOrEmpty(proxyPath)) {
+                if (!Strings.isNullOrEmpty(proxyPath)) {
                     proxy = new PEMCredential(proxyPath, (char[]) null);
                 } else {
                     clientCredential = new PEMCredential(clientKeyPath,


### PR DESCRIPTION
…oading

Motivation:

See GitHub #4427 : Bad xroot gsi TPC credential yields stack-trace

Modification:

Do not throw RuntimeExceptions but log the error.

This does not produce a "fail fast" response, but the failure will
occur soon enough since the loading occurs with each TPC client.

The alternative of altering the SPI signature seems incorrect from
the standpoint of abstraction (the specific exceptions should not
be exposed at that level).

This patch also fixes some faulty cert loading/caching logic.

Result:

No stack trace for IO or Security exceptions.

Target: master
Request: 3.3
Bug: dCache/dCache#4427
Acked-by: Paul