### PR TITLE
xrootd4j: restructure client pipeline error handling

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientSourceHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientSourceHandler.java
@@ -60,6 +60,7 @@ public abstract class AbstractClientSourceHandler extends
     @Override
     protected void doOnLoginResponse(ChannelHandlerContext ctx,
                                      InboundLoginResponse response)
+        throws XrootdException
     {
         ChannelId id = ctx.channel().id();
         XrootdTpcInfo tpcInfo = client.getInfo();
@@ -72,8 +73,7 @@ public abstract class AbstractClientSourceHandler extends
                                          tpcInfo.getSrc(),
                                          id,
                                          client.getStreamId());
-            exceptionCaught(ctx,
-                            new XrootdException(kXR_error, error));
+            throw new XrootdException(kXR_error, error);
         } else {
             LOGGER.trace("login of {} on {}, channel {}, stream {}, complete, "
                                          + "proceeding to open.",
@@ -88,6 +88,7 @@ public abstract class AbstractClientSourceHandler extends
     @Override
     protected void doOnAsynResponse(ChannelHandlerContext ctx,
                                     InboundAttnResponse response)
+                    throws XrootdException
     {
         switch (response.getRequestId()) {
             case kXR_open:
@@ -108,6 +109,7 @@ public abstract class AbstractClientSourceHandler extends
     @Override
     protected void doOnAuthenticationResponse(ChannelHandlerContext ctx,
                                               InboundAuthenticationResponse response)
+                    throws XrootdException
     {
         ChannelId id = ctx.channel().id();
         XrootdTpcInfo tpcInfo = client.getInfo();
@@ -123,6 +125,7 @@ public abstract class AbstractClientSourceHandler extends
     @Override
     protected void doOnCloseResponse(ChannelHandlerContext ctx,
                                      InboundCloseResponse response)
+                    throws XrootdException
     {
         int status = response.getStatus();
         ChannelId id = ctx.channel().id();
@@ -146,8 +149,7 @@ public abstract class AbstractClientSourceHandler extends
                                              id,
                                              client.getStreamId(),
                                              status);
-                exceptionCaught(ctx,
-                                new XrootdException(kXR_error, error));
+                throw new XrootdException(kXR_error, error);
         }
 
         client.setOpenFile(false);
@@ -156,7 +158,7 @@ public abstract class AbstractClientSourceHandler extends
     @Override
     protected void doOnOpenResponse(ChannelHandlerContext ctx,
                                     InboundOpenReadOnlyResponse response)
-
+                    throws XrootdException
     {
         int status = response.getStatus();
         ChannelId id = ctx.channel().id();
@@ -186,8 +188,7 @@ public abstract class AbstractClientSourceHandler extends
                             id,
                             client.getStreamId(),
                             status);
-            exceptionCaught(ctx,
-                            new XrootdException(kXR_error, error));
+            throw new XrootdException(kXR_error, error);
         }
     }
 
@@ -211,6 +212,7 @@ public abstract class AbstractClientSourceHandler extends
     @Override
     protected void doOnWaitResponse(final ChannelHandlerContext ctx,
                                     AbstractXrootdInboundResponse response)
+                    throws XrootdException
     {
         switch (response.getRequestId()) {
             case kXR_open:
@@ -233,7 +235,8 @@ public abstract class AbstractClientSourceHandler extends
      */
     @Override
     protected abstract void doOnChecksumResponse(ChannelHandlerContext ctx,
-                                                 InboundChecksumResponse response);
+                                                 InboundChecksumResponse response)
+                    throws XrootdException;
 
     /**
      *  Should implement the proper read logic.  If vector reads are supported,
@@ -241,17 +244,20 @@ public abstract class AbstractClientSourceHandler extends
      */
     @Override
     protected abstract void doOnReadResponse(ChannelHandlerContext ctx,
-                                             InboundReadResponse response);
+                                             InboundReadResponse response)
+                    throws XrootdException;
 
     /**
      *  If checksum option is expressed.
      */
     @Override
-    protected abstract void sendChecksumRequest(ChannelHandlerContext ctx);
+    protected abstract void sendChecksumRequest(ChannelHandlerContext ctx)
+                    throws XrootdException;
 
     /**
      *  Should take care of any special handling, such as vectorization.
      */
     @Override
-    protected abstract void sendReadRequest(ChannelHandlerContext ctx);
+    protected abstract void sendReadRequest(ChannelHandlerContext ctx)
+                    throws XrootdException;
 }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcClientConnectHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcClientConnectHandler.java
@@ -47,6 +47,7 @@ public class TpcClientConnectHandler extends
     @Override
     protected void doOnAsynResponse(ChannelHandlerContext ctx,
                                     InboundAttnResponse response)
+                    throws XrootdException
     {
         switch (response.getRequestId()) {
             case kXR_login:
@@ -72,6 +73,7 @@ public class TpcClientConnectHandler extends
     @Override
     protected void doOnProtocolResponse(ChannelHandlerContext ctx,
                                         InboundProtocolResponse response)
+                    throws XrootdException
     {
         int status = response.getStatus();
         ChannelId id = ctx.channel().id();
@@ -97,14 +99,14 @@ public class TpcClientConnectHandler extends
                             id,
                             streamId,
                             status);
-            exceptionCaught(ctx,
-                            new XrootdException(kXR_error, error));
+            throw new XrootdException(kXR_error, error);
         }
     }
 
     @Override
     protected void doOnLoginResponse(ChannelHandlerContext ctx,
                                      InboundLoginResponse response)
+                    throws XrootdException
     {
         int status = response.getStatus();
         ChannelId id = ctx.channel().id();
@@ -127,14 +129,14 @@ public class TpcClientConnectHandler extends
                                          id,
                                          streamId,
                                          status);
-            exceptionCaught(ctx,
-                            new XrootdException(kXR_error, error));
+            throw new XrootdException(kXR_error, error);
         }
     }
 
     @Override
     protected void doOnWaitResponse(final ChannelHandlerContext ctx,
                                     AbstractXrootdInboundResponse response)
+                    throws XrootdException
     {
         switch (response.getRequestId()) {
             case kXR_login:

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSourceReadHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSourceReadHandler.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.TimeUnit;
 
+import org.dcache.xrootd.core.XrootdException;
 import org.dcache.xrootd.tpc.protocol.messages.AbstractXrootdInboundResponse;
 import org.dcache.xrootd.tpc.protocol.messages.InboundAttnResponse;
 import org.dcache.xrootd.tpc.protocol.messages.InboundChecksumResponse;
@@ -49,6 +50,7 @@ public abstract class TpcSourceReadHandler extends AbstractClientSourceHandler
     @Override
     protected void doOnAsynResponse(ChannelHandlerContext ctx,
                                     InboundAttnResponse response)
+                    throws XrootdException
     {
         switch (response.getRequestId()) {
             case kXR_read:
@@ -65,6 +67,7 @@ public abstract class TpcSourceReadHandler extends AbstractClientSourceHandler
     @Override
     protected void doOnChecksumResponse(ChannelHandlerContext ctx,
                                         InboundChecksumResponse response)
+                    throws XrootdException
     {
         int status = response.getStatus();
         XrootdTpcInfo tpcInfo = client.getInfo();
@@ -180,6 +183,7 @@ public abstract class TpcSourceReadHandler extends AbstractClientSourceHandler
     @Override
     protected void doOnWaitResponse(final ChannelHandlerContext ctx,
                                     AbstractXrootdInboundResponse response)
+                    throws XrootdException
     {
         switch (response.getRequestId()) {
             case kXR_read:
@@ -251,7 +255,8 @@ public abstract class TpcSourceReadHandler extends AbstractClientSourceHandler
     }
 
     protected abstract void validateChecksum(InboundChecksumResponse response,
-                                             ChannelHandlerContext ctx);
+                                             ChannelHandlerContext ctx)
+                    throws XrootdException;
 
     protected abstract int getChunkSize();
 }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
@@ -478,10 +478,10 @@ public class XrootdTpcClient
             errno = kXR_ServerError;
         } else if (t instanceof IOException) {
             errno = kXR_IOError;
-        } else if (t instanceof Exception) {
-            errno = kXR_error;
-        } else {
+        } else if (t instanceof RuntimeException) {
             errno = kXR_ServerError;
+        } else {
+            errno = kXR_error;
         }
 
         writeHandler.fireDelayedSync(errno, error);


### PR DESCRIPTION
Motivation:

Code should avoid constructing an exception and then
passing it off to an exception handler.  The exception
should be thrown and caught.

Modification:

Change the 'doOn...' methods in the handlers to
throw an XrootdException.

Change the requestReceived method to place calls
to those handlers inside a try...catch block.

Have the catch block then pass the exception to
the exceptionCaught method, to ensure that
the client is properly closed, so that the
caller gets a response from the source server.

Result:

Code which conforms to best practice.

Target: master
Request: 3.3
Acked-by: Tigran