### PR TITLE
xrootd4j: correctly handle multiple authn protocols as indicated by s…

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/SecurityInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/SecurityInfo.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ *
+ * This file is part of xrootd4j.
+ *
+ * xrootd4j is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * xrootd4j is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with xrootd4j.  If not, see http://www.gnu.org/licenses/.
+ */
+
+package org.dcache.xrootd.security;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.dcache.xrootd.core.XrootdException;
+
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_error;
+
+/**
+ * <p>Utility class for holding security requirement information.</p>
+ */
+public class SecurityInfo {
+
+    /**
+     * @param sec the security information included in the Login response.
+     * @return list of security protocols supported by server, in the order
+     *         supplied by the server.
+     */
+    public static List<SecurityInfo> parse(String sec)
+                    throws XrootdException
+    {
+        List<SecurityInfo> info = new ArrayList<>();
+
+        String[] protocols = sec.trim().split("[&]");
+
+        String protocol;
+        String version;
+        String encryption;
+        String[] caIdentities;
+
+        for (int i = 1; i < protocols.length; ++i) {
+            version = null;
+            encryption = null;
+            caIdentities = null;
+
+            String[] parts = protocols[i].split("[,]");
+
+            if (!parts[0].startsWith("P=")) {
+                throw new XrootdException(kXR_error, "Malformed 'sec': " + sec);
+            }
+
+            protocol = parts[0].substring(2).trim();
+
+            for (int j = 1; j < parts.length; ++j) {
+                String[] keyVal = parts[j].split("[:]");
+                switch (keyVal[0].toLowerCase()) {
+                    case "v":
+                        version = keyVal[1];
+                        break;
+                    case "c":
+                        encryption = keyVal[1];
+                        break;
+                    case "ca":
+                        caIdentities = keyVal[1].split("[|]");
+                        break;
+                }
+            }
+
+            info.add(new SecurityInfo(protocol, version, encryption, caIdentities));
+        }
+
+        return info;
+    }
+
+    private final String   protocol;
+    private final String   version;
+    private final String   encryption;
+    private final String[] caIdentities;
+
+    private SecurityInfo(String protocol,
+                         String version,
+                         String encryption,
+                         String[] caIdentities)
+    {
+        this.protocol = protocol;
+        this.version = version;
+        this.encryption = encryption;
+        this.caIdentities = caIdentities;
+    }
+
+    public String[] getCaIdentities()
+    {
+        return caIdentities;
+    }
+
+    public String getEncryption()
+    {
+        return encryption;
+    }
+
+    public String getProtocol()
+    {
+        return protocol;
+    }
+
+    public String getVersion()
+    {
+        return version;
+    }
+
+    public String toString()
+    {
+        return "(protocol " + protocol
+                        + ")(version " + version
+                        + ")(encryption " + encryption
+                        + ")(caIdentities " + (caIdentities == null ? null :
+                            Arrays.asList(caIdentities)) + ")";
+    }
+}

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientRequestHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientRequestHandler.java
@@ -184,9 +184,8 @@ public abstract class AbstractClientRequestHandler extends
                                      InboundErrorResponse response)
                     throws XrootdException
     {
-        exceptionCaught(ctx,
-                        new XrootdException(response.getError(),
-                                            response.getErrorMessage()));
+        throw new XrootdException(response.getError(),
+                                  response.getErrorMessage());
     }
 
     protected void doOnHandshakeResponse(ChannelHandlerContext ctx,
@@ -251,11 +250,7 @@ public abstract class AbstractClientRequestHandler extends
                      response.getPort(),
                      id, client.getStreamId(),
                      client.getInfo());
-        try {
-            client.getWriteHandler().redirect(ctx, response);
-        } catch (XrootdException e) {
-            exceptionCaught(ctx, e);
-        }
+        client.getWriteHandler().redirect(ctx, response);
     }
 
     protected void doOnAttnResponse(ChannelHandlerContext ctx,

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientSourceHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientSourceHandler.java
@@ -64,8 +64,7 @@ public abstract class AbstractClientSourceHandler extends
     {
         ChannelId id = ctx.channel().id();
         XrootdTpcInfo tpcInfo = client.getInfo();
-        String sec = response.getSec();
-        if (sec != null) {
+        if (!response.getProtocols().isEmpty()) {
             String error = String.format("Authentication of %s on %s, "
                             + "channel %s, stream %d, is required; "
                             + "not handled.",


### PR DESCRIPTION
…erver

Motivation:

While not clearly indicated in the xrootd protocol documentation,
it is logically possible for the server to indicate in its login
response a list of authentication protocols to be tried, one
after the other.  These are indicated in the 'sec' data by
successive '&P=' segments.

Currently we are not handling these correctly.  The GSI module
in particular assumes only one protocol will be defined;
the TPC client also loads all such modules in the order
specified in the dCache configuration, so they will sit
in the pipeline in that sequence, not in the sequence
required by the server.

Modification:

Move the parsing to a special class to hold this information.
Process this information into a list and a map (for easy
reference) in the LoginResponse.

Have the connect handler access this information and add
the necessary handlers to the pipeline.  These handlers,
constructed from the plugin factories,
are now stored in the client in a map until they are
needed.

The authentication handlers also need to behave differently
on exceptions.  Instead of failing fast, they need to
pass the original login response downstream to the
next handler.

Result:

No current change in behavior, since we only support GSI,
but we avoid potential parsing issues should servers send
back multiple protocol indications.

Target: master
Request: 3.3
Acked-by: Tigran