### PR TITLE
xrootd4j: append zero-padding when TlsPremaster truncates it (on encr…

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/DHSession.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/DHSession.java
@@ -78,6 +78,44 @@ public class DHSession
             + "1a:d3:75:c7:c0:3b:61:aa:85:3f:56:69:ae:f2:67:"
             + "da:20:87:5d:93" ).replaceAll("[:\\s]+", "");
 
+    /**
+     * Use of the TlsPremasterSecret encoding on encryption can sometimes produce
+     * an array where the final 0's have been truncated.  This unfortunately
+     * does not play with the key finalization.   This method simply adds
+     * back the missing padding.
+     *
+     * Note:  the non-Tls encoding pads by prepending, not appending; this
+     * seems to be unacceptable to servers using the ssl DH_compute_key
+     * (unpadded) method.
+     */
+    private static byte[] adjustTruncatedPadding(byte[] defective, int blocksize)
+    {
+        byte[] encoded = new byte[blocksize];
+
+        System.arraycopy(defective, 0, encoded, 0, defective.length);
+
+        for (int i = defective.length; i < blocksize; ++i) {
+            encoded[i] = (byte)0;
+        }
+
+        LOGGER.info("Adjusting truncated encoded array by appending 0s; "
+                                    + "old {}, "
+                                    + "new {}.",
+                    printBytesAsHex(defective),
+                    printBytesAsHex(encoded));
+
+        return encoded;
+    }
+
+    private static String printBytesAsHex(byte[] array)
+    {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : array) {
+            sb.append(String.format("%02X ", b));
+        }
+        return sb.toString();
+    }
+
     // the 512 bit DH parameter set used for all DH sessions, consisting
     // of the prime above and the generator value of 2
     // These default values are only used when dCache acts as the server
@@ -228,16 +266,26 @@ public class DHSession
         Arrays.fill(iv, (byte)0);
         IvParameterSpec paramSpec = new IvParameterSpec(iv);
         Cipher cipher = Cipher.getInstance(cipherSpec,"BC");
+
         /**
          * "TlsPremasterSecret" algorithm forces pre 1.50
          * bouncy castle behavior ofgeneration of secret
          * for compatibility with xroord client
          */
+        byte[] encoded = _keyAgreement
+                        .generateSecret("TlsPremasterSecret")
+                        .getEncoded();
+
+        /*
+         *  The encoding is susceptible to truncation failure,
+         *  it would seem, only when the cipher is initialized for encryption.
+         */
+        if (encoded.length < blocksize && mode == Cipher.ENCRYPT_MODE) {
+            encoded = adjustTruncatedPadding(encoded, blocksize);
+        }
 
         /* need a 128-bit key, that's the way to get it */
-       SecretKey sessionKey = new SecretKeySpec(_keyAgreement
-                                                 .generateSecret("TlsPremasterSecret")
-                                                 .getEncoded(),
+        SecretKey sessionKey = new SecretKeySpec(encoded,
                                                  0,
                                                  blocksize,
                                                  keySpec);


### PR DESCRIPTION
…ypt)

Motivation:

Commit 93d5b48b1b13dc525de83eaa9929135207f2523c
addressed the problem of the incompatibility between
non-padded algorithms in the BouncyCastle and SLL
libraries.   The fix solved the problem for
incoming Diffie-Hellman parameters and key generation,
that is, where dCache had to decrypt using the secret
key.  For outgoing (dCache as TPC destination),
a different error would occur in which the buffer
size ended up being less than the block size, usually
by 1 byte (15, not 16).  This was infrequent (every
200-300 transfers), but warranted further investigation.

It turns out that the TlsPremaster algorithm, used
to maintain compatibility with the non-padded SSL
routine on the other end, seems to truncate leading
0s found in the non-Tls version.  Those initial
zeros are problematic on the SSL end, but the
size difference causes problems in the Cipher
initialization.  It turns out, however, that
padding the buffer at the end instead of the
beginning solves the problem.

Modification:

Check if the encoded buffer size is less than
blocksize, and if so, add 0-bytes to the end
up to blocksize.  Do this only if the
Cipher mode is encrypt.

Result:

The potential authentication error is avoided.

Target:  master
Request: 3.3
Acked-by: Dmitry