### PR TITLE
xrootd4j: prevent NPE when constructing error response

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandler.java
@@ -188,13 +188,14 @@ public class XrootdAuthenticationHandler extends ChannelInboundHandlerAdapter
             }
         } catch (XrootdException e) {
             ErrorResponse error =
-                new ErrorResponse<>(request, e.getError(), Strings.nullToEmpty(e.getMessage()));
+                new ErrorResponse<>(request, e.getError(), e.getMessage());
             ctx.writeAndFlush(error);
         } catch (RuntimeException e) {
             _log.error("xrootd server error while processing " + msg + " (please report this to support@dcache.org)", e);
             ErrorResponse error =
                 new ErrorResponse<>(request, kXR_ServerError,
-                                    String.format("Internal server error (%s)", e.getMessage()));
+                                    String.format("Internal server error (%s)",
+                                                  e.getMessage()));
             ctx.writeAndFlush(error);
         }
     }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdRequestHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdRequestHandler.java
@@ -18,7 +18,6 @@
  */
 package org.dcache.xrootd.core;
 
-import com.google.common.base.Strings;
 import com.google.common.net.InetAddresses;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -246,7 +245,7 @@ public class XrootdRequestHandler extends ChannelInboundHandlerAdapter
 
     protected <T extends XrootdRequest> ErrorResponse<T> withError(T req, int errorCode, String errMsg)
     {
-        return new ErrorResponse<>(req, errorCode, Strings.nullToEmpty(errMsg));
+        return new ErrorResponse<>(req, errorCode, errMsg);
     }
 
     protected ChannelFuture respond(ChannelHandlerContext ctx, Object response)

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ErrorResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ErrorResponse.java
@@ -18,6 +18,7 @@
  */
 package org.dcache.xrootd.protocol.messages;
 
+import com.google.common.base.Strings;
 import io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +38,7 @@ public class ErrorResponse<T extends XrootdRequest> extends AbstractXrootdRespon
     {
         super(request, XrootdProtocol.kXR_error);
         this.errnum = errnum;
-        this.errmsg = errmsg;
+        this.errmsg = Strings.nullToEmpty(errmsg);
         LOGGER.info("Xrootd-Error-Response: ErrorNr={} ErrorMsg={}", errnum, errmsg);
     }
 


### PR DESCRIPTION
Motivation:

When constructing an ErrorResponse, avoid a null message.
This is done in two places where the constructor is called,
but not in the third.   When data length is called, a null
message causes an NPE.

Modification:

Make the constructor do Strings.nullToEmpty on the parameter.

Result:

No NPE, and future calls to the constructor
need not explicitly call the Strings.nullToEmpty.

Target: master
Request: 3.3
Acked-by: Paul