### PR TITLE
xrootd4j: add ERROR status to tpc info

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
@@ -87,7 +87,7 @@ public class XrootdTpcInfo {
 
     public enum Status
     {
-        PENDING, READY, CANCELLED
+        PENDING, READY, CANCELLED, ERROR
     }
 
     /**
@@ -205,7 +205,7 @@ public class XrootdTpcInfo {
      *
      * <p>Will not overwrite existing non-null values.</p>
      */
-    public XrootdTpcInfo addInfoFromOpaque(String slfn,
+    public synchronized XrootdTpcInfo addInfoFromOpaque(String slfn,
                                            Map<String, String> opaque)
     {
         if (this.lfn == null) {
@@ -298,8 +298,12 @@ public class XrootdTpcInfo {
         return info;
     }
 
-    public Status verify(String dst, String slfn, String org)
+    public synchronized Status verify(String dst, String slfn, String org)
     {
+        if (this.status == Status.ERROR) {
+            return this.status;
+        }
+
         if (this.dst == null) {
             /*
              *  Client open has not yet occurred.
@@ -425,7 +429,7 @@ public class XrootdTpcInfo {
         return srcPort;
     }
 
-    public Status getStatus()
+    public synchronized Status getStatus()
     {
         return status;
     }
@@ -486,7 +490,7 @@ public class XrootdTpcInfo {
         this.srcPort = srcPort;
     }
 
-    public void setStatus(Status status)
+    public synchronized void setStatus(Status status)
     {
         this.status = status;
     }


### PR DESCRIPTION
Motivation:

We need a way of invalidating the tpc info without
actually discarding it or evicting it from a cache.

Modfication:

Add Status.ERROR.  If verify() is called on this
info, it immediately returns this error status.

Result:

A destination server can now know, when it tries
to call open, for instance, that the client
open failed (so we do not rely on the client
to close the server connection in time).

Target: master
Request: 3.3
Acked-by: Tigran