### PR TITLE
xrootd4j-gsi: change the protocol version to int

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/BaseGSIAuthenticationHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/BaseGSIAuthenticationHandler.java
@@ -41,7 +41,7 @@ import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_error;
 class BaseGSIAuthenticationHandler
 {
     public static final String PROTOCOL = "gsi";
-    public static final String PROTOCOL_VERSION = "10200";
+    public static final int PROTOCOL_VERSION = 10200;
     public static final String CRYPTO_MODE = "ssl";
 
     /**

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationHandler.java
@@ -51,6 +51,7 @@ import org.dcache.xrootd.security.NestedBucketBuffer;
 import org.dcache.xrootd.security.RawBucket;
 import org.dcache.xrootd.security.SecurityInfo;
 import org.dcache.xrootd.security.StringBucket;
+import org.dcache.xrootd.security.UnsignedIntBucket;
 import org.dcache.xrootd.security.XrootdBucket;
 import org.dcache.xrootd.security.XrootdSecurityProtocol.BucketType;
 import org.dcache.xrootd.tpc.AbstractClientRequestHandler;
@@ -267,9 +268,9 @@ public class GSIClientAuthenticationHandler extends AbstractClientRequestHandler
 
     class OutboundRequestBuckets implements BucketContainerBuilder
     {
-        private StringBucket cryptoBucket;
-        private StringBucket versionBucket;
-        private StringBucket issuerBucket;
+        private StringBucket       cryptoBucket;
+        private UnsignedIntBucket  versionBucket;
+        private StringBucket       issuerBucket;
         private NestedBucketBuffer mainBucket;
 
         OutboundRequestBuckets(String rtag) throws XrootdException {
@@ -280,8 +281,7 @@ public class GSIClientAuthenticationHandler extends AbstractClientRequestHandler
             mainBucket = new NestedBucketBuffer(kXRS_main, PROTOCOL, kXGC_certreq,
                                                 nestedBuckets);
             cryptoBucket = new StringBucket(kXRS_cryptomod, CRYPTO_MODE);
-            versionBucket = new StringBucket(kXRS_version,
-                                             PROTOCOL_VERSION.substring(0, 4));
+            versionBucket = new UnsignedIntBucket(kXRS_version, PROTOCOL_VERSION);
             issuerBucket = new StringBucket(kXRS_issuer_hash, issuerHashes);
         }
 


### PR DESCRIPTION
Motivation:

protocol version should be an int.

Modification:

change it from string

Result:

We can now do TPC as destination to a 4.9 server.

Target: master
Request: 3.3
Acked-by: Tigran