### PR TITLE
copyright header: bump year to 2019

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientRequestHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *


### PR DESCRIPTION
Motivation:

xrootd4j requires that the copyright year matches the year of the last
commit.  The class org.dcache.xrootd.tpc.AbstractClient was updated late
in 2018.  The copyright year shows a range ending in 2018, which is fine.

However, a recent pull request updated this file in the release/3.3
branch.  This poll request was accepted in 2019, which then requires the
.java file has a copyright header with a year range that ends in 2019.

The pull request failed to do this, therefore we are now unable to tag a
release.

Modification:

Bump the year to 2019.

Result:

Should now be able to tag the release/3.3 branch.

Target: master
Request: release/3.3
Patch: https://rb.dcache.org/r/11505/
Acked-by: Albert Rossi