### PR TITLE
xrootd4j: do not reject 4.9 client

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIAuthenticationHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIAuthenticationHandler.java
@@ -31,7 +31,6 @@ import org.dcache.xrootd.protocol.messages.XrootdResponse;
 import org.dcache.xrootd.security.BufferDecrypter;
 
 import static org.dcache.xrootd.plugins.authn.gsi.GSIRequestHandler.CRYPTO_MODE;
-import static org.dcache.xrootd.plugins.authn.gsi.GSIRequestHandler.PROTO_WITH_DELEGATION;
 import static org.dcache.xrootd.plugins.authn.gsi.GSIRequestHandler.PROTOCOL;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_InvalidRequest;
 import static org.dcache.xrootd.security.XrootdSecurityProtocol.*;
@@ -161,28 +160,10 @@ public class GSIAuthenticationHandler implements AuthenticationHandler
                             + "provide GSI protocol version number.");
         }
 
-        GSIServerRequestHandler handler;
-
         /*
-         *  If the client supports a protocol of 4.9 or later,
-         *  currently fail.  The client is only informed of the server
-         *  version to use once.  If it insists on using 4.9, this
-         *  cannot be supported until implemented.
-         *
-         *  Else, use the previous.
+         *  REVISIT:  return Pre49 or 49 according to clientVersion
+         *            when new handler is implemented.
          */
-        if (clientVersion >= PROTO_WITH_DELEGATION) {
-            /*
-             *  REVISIT  return 49 version when implemented.
-             */
-            throw new XrootdException(kGSErrBadProtocol,
-                                      "This server does not support "
-                                                      + "protocol version "
-                                                      + clientVersion);
-        } else {
-            handler = new GSIPre49ServerRequestHandler(subject, credentialManager);
-        }
-
-        return handler;
+        return new GSIPre49ServerRequestHandler(subject, credentialManager);
     }
 }


### PR DESCRIPTION
Motivation:

In preparation for supporting two different protocols,
the GSI handler checks versions and tries to match.

However, the code currently rejects the 4.9 client
saying it does not support it.   This is not necessary
and has caused our WLCG-DOMA deployment to be incompatible
with the testbed client.

Modification:

Accept 10400 client version and just use the current
client protocol.  The 10400 client should be
backward compatible.

Result:

Testbed should work again.

Target: master
Request: 3.4
Acked-by:  Paul