### PR TITLE
xrootd4j: add timer for TPC request/response, with timeout exception

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationHandler.java
@@ -171,6 +171,7 @@ public class GSIClientAuthenticationHandler extends AbstractClientAuthnHandler
         client.setAuthResponse(null);
         ctx.writeAndFlush(request, ctx.newPromise())
            .addListener(FIRE_EXCEPTION_ON_FAILURE);
+        client.startTimer(ctx);
     }
 
     private GSIClientRequestHandler createRequestHandler()

--- a/xrootd4j-unix/src/main/java/org/dcache/xrootd/plugins/authn/unix/UnixClientAuthenticationHandler.java
+++ b/xrootd4j-unix/src/main/java/org/dcache/xrootd/plugins/authn/unix/UnixClientAuthenticationHandler.java
@@ -123,5 +123,6 @@ public class UnixClientAuthenticationHandler extends AbstractClientAuthnHandler
         client.setAuthResponse(null);
         ctx.writeAndFlush(request, ctx.newPromise())
            .addListener(FIRE_EXCEPTION_ON_FAILURE);
+        client.startTimer(ctx);
     }
 }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientRequestHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientRequestHandler.java
@@ -75,6 +75,7 @@ public abstract class AbstractClientRequestHandler extends
     public void channelRead(ChannelHandlerContext ctx, Object msg)
     {
         if (msg instanceof XrootdInboundResponse) {
+            client.stopTimer();
             responseReceived(ctx, (XrootdInboundResponse) msg);
             return;
         }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientSourceHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientSourceHandler.java
@@ -206,6 +206,7 @@ public abstract class AbstractClientSourceHandler extends
                                                           client.getFullpath()),
                           ctx.newPromise())
            .addListener(FIRE_EXCEPTION_ON_FAILURE);
+        client.startTimer(ctx);
     }
 
     @Override

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcClientConnectHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcClientConnectHandler.java
@@ -210,6 +210,7 @@ public class TpcClientConnectHandler extends
                                                    tpcInfo.getLoginToken()),
                           ctx.newPromise())
            .addListener(FIRE_EXCEPTION_ON_FAILURE);
+        client.startTimer(ctx);
     }
 
     protected void sendProtocolRequest(ChannelHandlerContext ctx)
@@ -222,5 +223,6 @@ public class TpcClientConnectHandler extends
                                                       PROTOCOL_VERSION),
                           ctx.newPromise())
            .addListener(FIRE_EXCEPTION_ON_FAILURE);
+        client.startTimer(ctx);
     }
 }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSourceReadHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSourceReadHandler.java
@@ -232,6 +232,7 @@ public abstract class TpcSourceReadHandler extends AbstractClientSourceHandler
                                                   getChunkSize()),
                           ctx.newPromise())
            .addListener(FIRE_EXCEPTION_ON_FAILURE);
+        client.startTimer(ctx);
     }
 
     @Override
@@ -249,6 +250,7 @@ public abstract class TpcSourceReadHandler extends AbstractClientSourceHandler
                                                       tpcInfo.getLfn()),
                           ctx.newPromise())
            .addListener(FIRE_EXCEPTION_ON_FAILURE);
+        client.startTimer(ctx);
     }
 
     protected abstract void validateChecksum(InboundChecksumResponse response,

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
@@ -39,7 +39,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.dcache.xrootd.core.XrootdSessionIdentifier;
 import org.dcache.xrootd.plugins.ChannelHandlerFactory;
@@ -69,6 +71,9 @@ public class XrootdTpcClient
 {
     private static final Logger              LOGGER
                     = LoggerFactory.getLogger(XrootdTpcClient.class);
+
+    private static final int DISCONNECT_TIMEOUT_IN_SECONDS = 5;
+    private static final int DEFAULT_RESPONSE_TIMEOUT_IN_SECONDS = 2;
 
     private static int lastId = 1;
 
@@ -138,6 +143,10 @@ public class XrootdTpcClient
     private boolean isRunning;
     private int redirects;
     private long timeOfFirstRedirect;
+
+    private long responseTimeout = DEFAULT_RESPONSE_TIMEOUT_IN_SECONDS;
+
+    private ScheduledFuture timerTask;
 
     public XrootdTpcClient(String userUrn,
                            XrootdTpcInfo info,
@@ -326,12 +335,34 @@ public class XrootdTpcClient
          * It is not predictable whether the server will reply to an
          * endsession request, so this timed delay guarantees shutdown.
          */
-        executorService.schedule(new Runnable() {
-            @Override
-            public void run() {
-                disconnect();
-            }
-        }, 5, TimeUnit.SECONDS);
+        executorService.schedule(() -> disconnect(),
+                                 DISCONNECT_TIMEOUT_IN_SECONDS,
+                                 TimeUnit.SECONDS);
+    }
+
+    public synchronized void startTimer(final ChannelHandlerContext ctx) {
+        /*
+         *  just in case ...
+         */
+        stopTimer();
+        timerTask = executorService.schedule(() ->
+                                             {
+                                                 setError(getTimeoutException());
+                                                 try {
+                                                     shutDown(ctx);
+                                                 } catch (InterruptedException e) {
+                                                     e.printStackTrace();
+                                                 }
+                                             },
+                                             responseTimeout,
+                                             TimeUnit.SECONDS);
+    }
+
+    public synchronized void stopTimer() {
+        if (timerTask != null) {
+            timerTask.cancel(true);
+            timerTask = null;
+        }
     }
 
     public ChannelFuture getChannelFuture()
@@ -573,6 +604,16 @@ public class XrootdTpcClient
                                   .append(new Date(timeOfFirstRedirect))
                                   .append(")")
                                   .toString();
+    }
+
+    public void setResponseTimeout(long responseTimeout) {
+        this.responseTimeout = responseTimeout;
+    }
+
+    private TimeoutException getTimeoutException() {
+        return new TimeoutException("No response from server after "
+                                                    + responseTimeout
+                                                    + " seconds.");
     }
 
     private void injectHandlers(ChannelPipeline pipeline,


### PR DESCRIPTION
Motivation:

If for some reason a server does not respond to
the TPC client, there is currently the potential
for it to wait indefinitely.

Modification:

Add a response timer start and stop call to
the TPC client.  If the response does not
arrive within a fixed interval (currently
set at 30 seconds), throw a TimeoutException
back to the client and shutdown.

Result:

Hopefully no stalling when a server behaves
badly, but rather a client disconnect
and error thrown back to the originator.

Target: master
Request: 3.5
Request: 3.4
Acked-by: Tigran