### PR TITLE
xrootd4j: add timer for TPC request/response, with timeout exception

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationHandler.java
@@ -532,6 +532,7 @@ public class GSIClientAuthenticationHandler extends AbstractClientRequestHandler
         client.setAuthResponse(null);
         ctx.writeAndFlush(request, ctx.newPromise())
            .addListener(FIRE_EXCEPTION_ON_FAILURE);
+        client.startTimer(ctx);
     }
 
     /**

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientRequestHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientRequestHandler.java
@@ -75,6 +75,7 @@ public abstract class AbstractClientRequestHandler extends
     public void channelRead(ChannelHandlerContext ctx, Object msg)
     {
         if (msg instanceof XrootdInboundResponse) {
+            client.stopTimer();
             responseReceived(ctx, (XrootdInboundResponse) msg);
             return;
         }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientSourceHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientSourceHandler.java
@@ -206,6 +206,7 @@ public abstract class AbstractClientSourceHandler extends
                                                           client.getFullpath()),
                           ctx.newPromise())
            .addListener(FIRE_EXCEPTION_ON_FAILURE);
+        client.startTimer(ctx);
     }
 
     @Override

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcClientConnectHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcClientConnectHandler.java
@@ -204,6 +204,7 @@ public class TpcClientConnectHandler extends
                                                    tpcInfo.getLoginToken()),
                           ctx.newPromise())
            .addListener(FIRE_EXCEPTION_ON_FAILURE);
+        client.startTimer(ctx);
     }
 
     protected void sendProtocolRequest(ChannelHandlerContext ctx)
@@ -216,5 +217,6 @@ public class TpcClientConnectHandler extends
                                                       PROTOCOL_VERSION),
                           ctx.newPromise())
            .addListener(FIRE_EXCEPTION_ON_FAILURE);
+        client.startTimer(ctx);
     }
 }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSourceReadHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSourceReadHandler.java
@@ -235,6 +235,7 @@ public abstract class TpcSourceReadHandler extends AbstractClientSourceHandler
                                                   getChunkSize()),
                           ctx.newPromise())
            .addListener(FIRE_EXCEPTION_ON_FAILURE);
+        client.startTimer(ctx);
     }
 
     @Override
@@ -252,6 +253,7 @@ public abstract class TpcSourceReadHandler extends AbstractClientSourceHandler
                                                       tpcInfo.getLfn()),
                           ctx.newPromise())
            .addListener(FIRE_EXCEPTION_ON_FAILURE);
+        client.startTimer(ctx);
     }
 
     protected abstract void validateChecksum(InboundChecksumResponse response,


### PR DESCRIPTION
Motivation:

If for some reason a server does not respond to
the TPC client, there is currently the potential
for it to wait indefinitely.

Modification:

Add a response timer start and stop call to
the TPC client.  If the response does not
arrive within a fixed interval (currently
set at 30 seconds), throw a TimeoutException
back to the client and shutdown.

Result:

Hopefully no stalling when a server behaves
badly, but rather a client disconnect
and error thrown back to the originator.

Target: master
Request: 3.5
Request: 3.4
Acked-by: Tigran