### PR TITLE
xrootd4j: fix two small security info bugs

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/SecurityInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/SecurityInfo.java
@@ -18,9 +18,8 @@
  */
 package org.dcache.xrootd.security;
 
-import com.google.common.base.Splitter;
-
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -46,11 +45,17 @@ public class SecurityInfo
             data = Collections.emptyMap();
         } else {
             protocol = description.substring(0, comma);
-            String keyValueData = description.substring(comma+1);
-            data = Splitter.on(',')
-                           .omitEmptyStrings()
-                           .withKeyValueSeparator(':')
-                           .split(keyValueData);
+            data = new HashMap<>();
+            String keyValueData = description.substring(comma + 1);
+            String[] kvPairs = keyValueData.split(",");
+            for (String pair: kvPairs) {
+                String[] keyValue = pair.split(":");
+                if (keyValue.length == 2) {
+                    data.put(keyValue[0], keyValue[1]);
+                } else {
+                    data.put(keyValue[0], keyValue[0]);
+                }
+            }
         }
 
         if (protocol.isEmpty()) {

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcClientConnectHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcClientConnectHandler.java
@@ -141,17 +141,16 @@ public class TpcClientConnectHandler extends
                 ChannelHandler handler = handlers.get(name);
                 if (handler != null) {
                     pipeline.addAfter(last, name, handler);
-                }
+                    last = name;
 
-                LOGGER.debug("Login to {}, channel {}, stream {}, sessionId {}, "
+                    LOGGER.debug("Login to {}, channel {}, stream {}, sessionId {}, "
                                              + "adding {} handler to pipeline.",
                              tpcInfo.getSrc(),
                              id,
                              streamId,
                              client.getSessionId(),
                              name);
-
-                last = name;
+                }
             }
 
             LOGGER.debug("Login to {}, channel {}, stream {},"


### PR DESCRIPTION
Motivation:

Unlike other implementations of xrootd, EOS also
provides for security protocols other than gsi.
Parsing and handling that information currently
fails in dCache on TPC because of two small bugs:

1.  The comma-segments of the sec information on
    login need not contain a ':'-separated key-value;
2.  The assignment of the current module name to last
    in the loop which adds handlers to the pipeline
    should only occur if the handler of that type
    was actually added.

Modification:

The parsing has been fixed and the assignment moved
(along with the logging statement) inside the
conditional block where it belongs.

Result:

Correct parsing and pipeline injection.

Target: master
Request: 3.5
Acked-by: Tigran