### PR TITLE
xrootd4j: correct tpc config issues to enable delegation

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/post49/GSIPost49ClientRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/post49/GSIPost49ClientRequestHandler.java
@@ -63,6 +63,11 @@ public class GSIPost49ClientRequestHandler extends GSIClientRequestHandler
                                          XrootdTpcClient client)
     {
         super(credentialManager, client);
+        /*
+         *  Request handler was chosen because endpoint supports delegation.
+         *  Let the client know this.
+         */
+        client.getAuthnContext().put("tpcdlg", "gsi");
     }
 
     @Override

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/pre49/GSIPre49ClientRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/pre49/GSIPre49ClientRequestHandler.java
@@ -38,6 +38,12 @@ public class GSIPre49ClientRequestHandler extends GSIClientRequestHandler
                                         XrootdTpcClient client)
     {
         super(credentialManager, client);
+        /*
+         *  Request handler was chosen because endpoint
+         *  does not support delegation.
+         *  Let the client know this.
+         */
+        client.getAuthnContext().put("tpcdlg", "tpcdlg");
     }
 
     @Override

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/XrootdProtocol.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/XrootdProtocol.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -29,6 +29,7 @@ public interface XrootdProtocol {
     public static final byte PROTOCOL_VERSION_MINOR =
         (byte) (PROTOCOL_VERSION & 0x00FF);
     public static final byte CLIENT_PROTOCOL_VERSION = (byte)4;
+    public static final int TPC_VERSION = 1;
 
     public static final byte      CLIENT_REQUEST_LEN = 24;
     public static final byte    CLIENT_HANDSHAKE_LEN = 20;

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
@@ -18,6 +18,7 @@
  */
 package org.dcache.xrootd.tpc;
 
+import com.google.common.base.Strings;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -73,7 +74,7 @@ public class XrootdTpcClient
                     = LoggerFactory.getLogger(XrootdTpcClient.class);
 
     private static final int DISCONNECT_TIMEOUT_IN_SECONDS = 5;
-    private static final int DEFAULT_RESPONSE_TIMEOUT_IN_SECONDS = 2;
+    private static final int DEFAULT_RESPONSE_TIMEOUT_IN_SECONDS = 30;
 
     private static int lastId = 1;
 
@@ -96,7 +97,6 @@ public class XrootdTpcClient
     private final Map<String, ChannelHandler> authnHandlers;
     private final int                        pid;
     private final String                     uname;
-    private final String                     fullpath;
 
     private final ScheduledExecutorService executorService;
 
@@ -143,7 +143,6 @@ public class XrootdTpcClient
     private boolean isRunning;
     private int redirects;
     private long timeOfFirstRedirect;
-
     private long responseTimeout = DEFAULT_RESPONSE_TIMEOUT_IN_SECONDS;
 
     private ScheduledFuture timerTask;
@@ -177,25 +176,6 @@ public class XrootdTpcClient
          */
         uname = userSplit[0];
         pid = Integer.parseInt(userSplit[1]);
-
-        String external = info.getExternal();
-        if (external == null) {
-            external = "";
-        } else {
-            external = OpaqueStringParser.OPAQUE_PREFIX + external;
-        }
-
-        fullpath = info.getLfn()
-                        + OpaqueStringParser.OPAQUE_STRING_PREFIX
-                        + XrootdTpcInfo.RENDEZVOUS_KEY
-                        + OpaqueStringParser.OPAQUE_SEPARATOR
-                        + info.getKey()
-                        + OpaqueStringParser.OPAQUE_PREFIX
-                        + XrootdTpcInfo.CLIENT
-                        + OpaqueStringParser.OPAQUE_SEPARATOR
-                        + userUrn
-                        + external;
-
         writeOffset = 0L;
         errno = kXR_ok;
         redirects = 0;
@@ -219,6 +199,7 @@ public class XrootdTpcClient
         this.timeOfFirstRedirect = preceding.timeOfFirstRedirect <= 0 ?
                         System.currentTimeMillis() :
                         preceding.timeOfFirstRedirect;
+        this.responseTimeout = preceding.responseTimeout;
     }
 
     public synchronized void connect(final NioEventLoopGroup group,
@@ -422,8 +403,39 @@ public class XrootdTpcClient
 
     public String getFullpath()
     {
-        LOGGER.debug("Client asked for full path: {}.", this);
-        return fullpath;
+        StringBuilder fullPath = new StringBuilder();
+
+        /*
+         *  If delegation is not being used, forward the rendezvous key and
+         *  client info.
+         */
+        String protocol = (String)authnContext.get("protocol");
+        String tpcDlg = (String)authnContext.get("tpcdlg");
+        if ("gsi".equals(protocol) && !"gsi".equalsIgnoreCase(tpcDlg)) {
+            fullPath.append(XrootdTpcInfo.CLIENT)
+                    .append(OpaqueStringParser.OPAQUE_SEPARATOR)
+                    .append(userUrn)
+                    .append(OpaqueStringParser.OPAQUE_PREFIX)
+                    .append(XrootdTpcInfo.RENDEZVOUS_KEY)
+                    .append(OpaqueStringParser.OPAQUE_SEPARATOR)
+                    .append(info.getKey());
+        }
+
+        String external = info.getExternal();
+        if (!Strings.isNullOrEmpty(external)) {
+            if (fullPath.length() > 0) {
+                fullPath.append(OpaqueStringParser.OPAQUE_PREFIX);
+            }
+            fullPath.append(external);
+        }
+
+        if (fullPath.length() > 0) {
+            fullPath.insert(0, OpaqueStringParser.OPAQUE_STRING_PREFIX);
+        }
+
+        fullPath.insert(0, info.getLfn());
+
+        return fullPath.toString();
     }
 
     public XrootdTpcInfo getInfo()
@@ -538,6 +550,10 @@ public class XrootdTpcClient
         this.pval = pval;
     }
 
+    public void setResponseTimeout(long responseTimeout) {
+        this.responseTimeout = responseTimeout;
+    }
+
     public void setSessionId(XrootdSessionIdentifier sessionId)
     {
         this.sessionId = sessionId;
@@ -573,7 +589,7 @@ public class XrootdTpcClient
                                   .append(")(uname ")
                                   .append(uname)
                                   .append(")(fullpath ")
-                                  .append(fullpath)
+                                  .append(getFullpath())
                                   .append(")(expectedRequestId ")
                                   .append(expectedRequestId)
                                   .append(")(pval ")
@@ -604,10 +620,6 @@ public class XrootdTpcClient
                                   .append(new Date(timeOfFirstRedirect))
                                   .append(")")
                                   .toString();
-    }
-
-    public void setResponseTimeout(long responseTimeout) {
-        this.responseTimeout = responseTimeout;
     }
 
     private TimeoutException getTimeoutException() {

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
@@ -50,6 +50,8 @@ public class XrootdTpcInfo {
 
     public static final String SRC = "tpc.src";
 
+    public static final String DLG = "tpc.dlg";
+
     public static final String DST = "tpc.dst";
 
     public static final String LOGICAL_NAME = "tpc.lfn";
@@ -61,6 +63,16 @@ public class XrootdTpcInfo {
     public static final String TIME_TO_LIVE = "tpc.ttl";
 
     public static final String SIZE_IN_BYTES = "oss.asize";
+
+    /*
+     * Unused, but these need to be eliminated from
+     * the path if delegation is supported.
+     */
+    public static final String STR = "tpc.str";
+
+    public static final String TPR = "tpc.tpr";
+
+    public static final String SPR = "tpc.spr";
 
     /**
      * <p>Opaque string name-value constant values.</p>
@@ -84,7 +96,11 @@ public class XrootdTpcInfo {
                                       CLIENT,
                                       CHECKSUM,
                                       TIME_TO_LIVE,
-                                      SIZE_IN_BYTES);
+                                      SIZE_IN_BYTES,
+                                      STR,
+                                      DLG,
+                                      TPR,
+                                      SPR);
 
     public enum Status
     {
@@ -282,6 +298,7 @@ public class XrootdTpcInfo {
         info.asize = asize;
         info.cks = cks;
         info.loginToken = response.getToken();
+        info.delegatedProxy = delegatedProxy;
 
         String opaque = response.getOpaque();
 
@@ -530,8 +547,11 @@ public class XrootdTpcInfo {
 
     private void setSourceFromOpaque(Map<String, String> map)
     {
-        this.src = map.get(SRC);
-        if (this.src != null) {
+        src = map.get(DLG);
+        if (src == null) {
+            src = map.get(SRC);
+        }
+        if (src != null) {
             String[] source = this.src.split(":");
             this.srcHost = source[0];
             if (Strings.emptyToNull(source[1]) != null) {


### PR DESCRIPTION
Motivation:

The current implementation of third-party copy on the destination-side
using the TPC client is faulty in several respects.  This causes
tpc to fail on some servers like DPM.

Modification:

1)  the query for 'tpc' should return TCP protocol version, not the GSI protocol version.
    this is added to the protocol spec
2)  the opaque tpc ('cgi') data, in particular the rendezvous key, should not be
    included in the source path when the TPC client calls open and delegation
    is being used
3)  on DPM, there is a redirect from the head node to disk; the TPC client
    recomposes the TPC Info on redirect.  Currently, it is neglecting to
    include the delegated proxy in the new info; this is fixed.
4)  when delegation is used, tpc.dlg sometime indicates the point to
    start from, and should be preferred to tpc.src in this case as
    specifying the source endpoint.
5)  the new TPC Client constructed on redirect should have the same
    response timeout as the old.  Set it during configuration of
    redirect count.

Result:

TPC should now succeed.

Target: master
Request: 3.5
Acked-by: Tigran