### PR TITLE
xrootd4j: add checksum info to support cgi element*

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/ChecksumInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/ChecksumInfo.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ *
+ * This file is part of xrootd4j.
+ *
+ * xrootd4j is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * xrootd4j is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with xrootd4j.  If not, see http://www.gnu.org/licenses/.
+ */
+package org.dcache.xrootd.util;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.dcache.xrootd.core.XrootdException;
+
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_InvalidRequest;
+
+/**
+ *  Protocol 4.0+ allows for an optional checksum type specification
+ *  passed as an opaque/cgi element on the path.
+ */
+public class ChecksumInfo
+{
+    private static final String KEY = "cks.type";
+
+    private final String           path;
+    private final Optional<String> type;
+
+    public ChecksumInfo(String args) throws XrootdException
+    {
+        int i = args.indexOf("?");
+        if (i == -1) {
+            path = args;
+            type = Optional.empty();
+        } else {
+            path = args.substring(0, i);
+            String query = args.substring(i);
+            try {
+                Map<String, String> map
+                                = OpaqueStringParser.getOpaqueMap(query);
+                type = Optional.ofNullable(map.get(KEY));
+            } catch (ParseException e) {
+                throw new XrootdException(kXR_InvalidRequest,
+                                          "malformed checksum query part: "
+                                                          + query);
+            }
+        }
+    }
+
+    public String getPath()
+    {
+        return path;
+    }
+
+    public Optional<String> getType()
+    {
+        return type;
+    }
+}


### PR DESCRIPTION
Motivation:

Xrootd Protocol 4.0 specifies that the path on
a checksum query can have a query with the cgi
element 'cks.type' specifying the checksum type
from servers that support multiple types.

Modification:

Support this by adding a checksum info class which
parses the query argument.

Result:

dCache door is Protocol 4.0 compliant.

Target: master
Request: 3.5
Request: 3.4
Request: 3.3
Acked-by: Tigran