### PR TITLE
xrootd4j: fix OutboundProtocolRequest header

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/XrootdProtocol.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/XrootdProtocol.java
@@ -20,16 +20,17 @@ package org.dcache.xrootd.protocol;
 
 public interface XrootdProtocol {
 
-    /*  current supported protocol version: 2.89
+    /*  current supported protocol version: 400
      * Xrootd expects the protocol information binary encoded in an int32
      */
-    public static final int  PROTOCOL_VERSION = 0x289;
+    public static final int  PROTOCOL_VERSION       = 0x00000400;
+    public static final int  PROTOCOL_SIGN_VERSION  = 0x00000310;
     public static final byte PROTOCOL_VERSION_MAJOR =
         (byte) ((PROTOCOL_VERSION & 0xFF00) >> 8);
     public static final byte PROTOCOL_VERSION_MINOR =
         (byte) (PROTOCOL_VERSION & 0x00FF);
-    public static final byte CLIENT_PROTOCOL_VERSION = (byte)4;
-    public static final int TPC_VERSION = 1;
+    public static final byte CLIENT_CAPVER_VERSION  = (byte)4;
+    public static final int  TPC_VERSION            = 1;
 
     public static final byte      CLIENT_REQUEST_LEN = 24;
     public static final byte    CLIENT_HANDSHAKE_LEN = 20;

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundLoginRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundLoginRequest.java
@@ -21,7 +21,7 @@ package org.dcache.xrootd.tpc.protocol.messages;
 import io.netty.buffer.ByteBuf;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.dcache.xrootd.protocol.XrootdProtocol.CLIENT_PROTOCOL_VERSION;
+import static org.dcache.xrootd.protocol.XrootdProtocol.CLIENT_CAPVER_VERSION;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_login;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_useruser;
 
@@ -55,8 +55,8 @@ public class OutboundLoginRequest extends AbstractXrootdOutboundRequest
         buffer.writeByte(0);
         // ability –– nothing special
         buffer.writeByte(0);
-        // capver –– 00000001 (no async, client v. 1);
-        buffer.writeByte(CLIENT_PROTOCOL_VERSION);
+        // capver –– (no async, client version);
+        buffer.writeByte(CLIENT_CAPVER_VERSION);
         // role = user
         buffer.writeByte(kXR_useruser);
         if (token != null) {

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundProtocolRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundProtocolRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -32,14 +32,15 @@ import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_secreqs;
  *      <tr><td>kXR_char</td><td>streamid[2]</td></tr>
  *      <tr><td>kXR_unt16</td><td>kXR_protocol</td></tr>
  *      <tr><td>kXR_int32</td><td>clientpv</td></tr>
- *      <tr><td>kXR_char</td><td>reserved[11]</td></tr>
  *      <tr><td>kXR_char</td><td>options</td></tr>
+ *      <tr><td>kXR_char</td><td>expect</td></tr>
+ *      <tr><td>kXR_char</td><td>reserved[10]</td></tr>
  *      <tr><td>kXR_int32</td><td>dlen</td></tr>
  *  </table>
  */
 public class OutboundProtocolRequest implements XrootdOutboundRequest
 {
-    private static final byte[] RESERVED = {0,0,0,0,0,0,0,0,0,0,0};
+    private static final byte[] RESERVED = {0,0,0,0,0,0,0,0,0,0};
     private int streamId;
     private int version;
 
@@ -62,8 +63,9 @@ public class OutboundProtocolRequest implements XrootdOutboundRequest
             buffer.writeShort(streamId);
             buffer.writeShort(kXR_protocol);
             buffer.writeInt(version);
-            buffer.writeBytes(RESERVED);
             buffer.writeByte(kXR_secreqs);
+            buffer.writeByte(0);
+            buffer.writeBytes(RESERVED);
             buffer.writeInt(0);
         } catch (Error | RuntimeException t) {
             promise.setFailure(t);


### PR DESCRIPTION
Motivation:

In order for the xrootd client to know whether to honor
hash signing, the xrootd server must return security level
information to the client in the ProtocolResponse.

The server will do this only if the following conditions
pertain:

- the server's own version is >= 3.1.0
- the protocol version supported by the client is >= 3.1.0
- the client sets the option in the ProtocolRequest to 'kXR_secreqs'

Currently, there are two defects in the TPC client code
preventing the server from conveying its security level to
dCache during TPC with dCache as destination:  the
protocol version is out of date, and the byte ordering
of the ProtocolRequest is incorrect.

As a result, if the security level of the dCache server
is > 0, the transfer fails because the TPC client does
not honor hash signing.

Modification:

1.  Update the protocol version.
2.  Fix the byte order in the OutboundProtocolRequest

Result:

With `sec.level all pedantic` set on the xrootd server,
dCache now honors hash signing and TPC with dCache
as destination succeeds.

Target: master
Request: 3.5
Requires-book: no
Requires-notes: yes
Patch: https://rb.dcache.org/r/11925/
Acked-by:  Olufemi