### PR TITLE
xrootd4j: server should respect xrootd protocol with regard to securi…

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ProtocolRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ProtocolRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -18,13 +18,40 @@
  */
 package org.dcache.xrootd.protocol.messages;
 
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_protocol;
 import io.netty.buffer.ByteBuf;
 
+import static org.dcache.xrootd.protocol.XrootdProtocol.PROTOCOL_SIGN_VERSION;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_protocol;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_secreqs;
+
+/**
+ * <p>The kXR_protocol request has the following packet structure:</p>
+ *
+ *  <table>
+ *      <tr><td>kXR_char</td><td>streamid[2]</td></tr>
+ *      <tr><td>kXR_unt16</td><td>kXR_protocol</td></tr>
+ *      <tr><td>kXR_int32</td><td>clientpv</td></tr>
+ *      <tr><td>kXR_char</td><td>options</td></tr>
+ *      <tr><td>kXR_char</td><td>expect</td></tr>
+ *      <tr><td>kXR_char</td><td>reserved[10]</td></tr>
+ *      <tr><td>kXR_int32</td><td>dlen</td></tr>
+ *  </table>
+ */
 public class ProtocolRequest extends AbstractXrootdRequest
 {
+    private final int version;
+    private final int option;
+
     public ProtocolRequest(ByteBuf buffer)
     {
         super(buffer, kXR_protocol);
+        version = buffer.getInt(4);
+        option = buffer.getByte(8);
+    }
+
+    public boolean shouldReturnSecOpts()
+    {
+        return version >= PROTOCOL_SIGN_VERSION
+                        && (option & kXR_secreqs) == kXR_secreqs;
     }
 }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ProtocolResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ProtocolResponse.java
@@ -60,8 +60,7 @@ public class ProtocolResponse extends AbstractXrootdResponse<ProtocolRequest>
     private static final byte SECVER = 0;
 
     private final int           flags;
-    private final SigningPolicy signingPolicy;
-
+    private SigningPolicy       signingPolicy;
 
     public ProtocolResponse(ProtocolRequest request,
                             int flags)
@@ -91,7 +90,8 @@ public class ProtocolResponse extends AbstractXrootdResponse<ProtocolRequest>
     @Override
     public int getDataLength()
     {
-        return signingPolicy.isSigningOn() ? 14 : 8;
+        return (request.shouldReturnSecOpts()
+                        && signingPolicy.isSigningOn()) ? 14 : 8;
     }
 
     @Override


### PR DESCRIPTION
…ty info

Motivation:

According to the xrootd protocol document, the server
should only return its signing policy (security level
info) if the client is signing enabled and it requests
it.   Currently, dCache returns this info on the
protocol response indiscriminately.

Modification:

Check the version and option set by the client in
the protocol request.

Result:

Server only returns this info when asked, thus
complying with xrootd specifications.

Target: master
Request: 3.5
Requires-book: no
Requires-notes: yes
Patch: https://rb.dcache.org/r/11927/
Acked-by:  Vincent