### PR TITLE
xrootd4j: update and regularize use of error codes throughout library

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIAuthenticationHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIAuthenticationHandler.java
@@ -120,7 +120,7 @@ public class GSIAuthenticationHandler implements AuthenticationHandler
                 break;
             default:
                 requestHandler.cancelHandshake();
-                throw new XrootdException(kXR_InvalidRequest,
+                throw new XrootdException(kGSErrBadOpt,
                                           "Error during authentication, " +
                                                           "unknown processing step: "
                                                           + request.getStep());
@@ -175,7 +175,7 @@ public class GSIAuthenticationHandler implements AuthenticationHandler
              *  This method should be called only on the first exchange,
              *  so the client only needs to send it then (as it does).
              */
-            throw new XrootdException(kXR_InvalidRequest, "Client did not "
+            throw new XrootdException(kGSErrBadProtocol, "Client did not "
                             + "provide GSI protocol version number.");
         }
 

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationHandler.java
@@ -105,7 +105,7 @@ public class GSIClientAuthenticationHandler extends AbstractClientAuthnHandler
                 sendAuthenticationRequest(ctx);
                 break;
             default:
-                throw new XrootdException(kXR_ServerError,
+                throw new XrootdException(kGSErrBadOpt,
                                           "wrong status from GSI authentication "
                                                           + "response: "
                                                           + status);

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientRequestHandler.java
@@ -45,9 +45,10 @@ import org.dcache.xrootd.tpc.XrootdTpcClient;
 import org.dcache.xrootd.tpc.protocol.messages.InboundAuthenticationResponse;
 import org.dcache.xrootd.tpc.protocol.messages.OutboundAuthenticationRequest;
 
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_InvalidRequest;
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ServerError;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_DecryptErr;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_IOError;
 import static org.dcache.xrootd.security.XrootdSecurityProtocol.BucketType.*;
+import static org.dcache.xrootd.security.XrootdSecurityProtocol.kGSErrError;
 import static org.dcache.xrootd.security.XrootdSecurityProtocol.kXGC_cert;
 import static org.dcache.xrootd.security.XrootdSecurityProtocol.kXGC_certreq;
 
@@ -308,18 +309,18 @@ public abstract class GSIClientRequestHandler extends GSIRequestHandler
             LOGGER.error("Problems during cert step {}." +
                                          e.getMessage() == null ? e.getClass().getName() :
                                          e.getMessage());
-            throw new XrootdException(kXR_ServerError,
+            throw new XrootdException(kXR_IOError,
                                       "Internal error occurred during cert step.");
         } catch (InvalidKeyException e) {
             LOGGER.error("The key negotiated by DH key exchange appears to " +
                                          "be invalid: {}", e.getMessage());
-            throw new XrootdException(kXR_InvalidRequest,
+            throw new XrootdException(kXR_DecryptErr,
                                       "Could not decrypt server " +
                                                       "information with negotiated key.");
         } catch (GeneralSecurityException e) {
             LOGGER.error("Cryptographic issues encountered during cert step: {}",
                          e.getMessage());
-            throw new XrootdException(kXR_ServerError,
+            throw new XrootdException(kGSErrError,
                                       "Could not complete cert step: an error "
                                                       + "occurred during "
                                                       + "cryptographic operations.");

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSICredentialManager.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSICredentialManager.java
@@ -69,8 +69,7 @@ import org.dcache.xrootd.core.XrootdException;
 import org.dcache.xrootd.plugins.ProxyDelegationClient;
 import org.dcache.xrootd.util.ProxyRequest;
 
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ServerError;
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_error;
+import static org.dcache.xrootd.security.XrootdSecurityProtocol.kGSErrError;
 
 /**
  *  <p>Supports credential loading and creation for both server and client.</p>
@@ -225,7 +224,7 @@ public class GSICredentialManager
         }
 
         if (valid.isEmpty()) {
-            throw new XrootdException(kXR_error, "no ca identity is recognized.");
+            throw new XrootdException(kGSErrError, "no ca identity is recognized.");
         }
 
         LOGGER.debug("The following ca hashes are recognized: {}.", valid);
@@ -240,7 +239,7 @@ public class GSICredentialManager
             finalizeDelegatedProxy(X509Certificate[] certChain)
                     throws XrootdException {
         if (proxyRequest == null) {
-            throw new XrootdException(kXR_ServerError, "cannot finalize proxy: "
+            throw new XrootdException(kGSErrError, "cannot finalize proxy: "
                             + "proxy request was not sent.");
         }
 
@@ -315,7 +314,7 @@ public class GSICredentialManager
                                      + "from client for {}.",
                      certChain[0].getSubjectDN());
         if (proxyRequest == null) {
-            throw new XrootdException(kXR_ServerError, "fetch of proxy request "
+            throw new XrootdException(kGSErrError, "fetch of proxy request "
                             + "(CSR) failed");
         }
 
@@ -444,7 +443,7 @@ public class GSICredentialManager
     private X509ProxyDelegationClient proxyDelegationClient() throws XrootdException
     {
         if (proxyDelegationClient == null) {
-            throw new XrootdException(kXR_ServerError, "no client to credential "
+            throw new XrootdException(kGSErrError, "no client to credential "
                             + "store has been provided.");
         }
 

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIRequestHandler.java
@@ -54,7 +54,7 @@ import org.dcache.xrootd.security.XrootdSecurityProtocol.*;
 import static eu.emi.security.authn.x509.impl.CertificateUtils.Encoding.PEM;
 import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_InvalidRequest;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_DecryptErr;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_error;
 import static org.dcache.xrootd.security.XrootdSecurityProtocol.BucketType.*;
 import static org.dcache.xrootd.security.XrootdSecurityProtocol.*;
@@ -292,7 +292,7 @@ public abstract class GSIRequestHandler
      */
     protected void finalizeSessionKey(Map<BucketType, XrootdBucket> receivedBuckets,
                                       BucketType bucketType)
-                    throws IOException, GeneralSecurityException
+                    throws IOException, GeneralSecurityException, XrootdException
     {
         LOGGER.debug("Finalizing session key using bucket type {}.",
                      bucketType.name());
@@ -319,9 +319,10 @@ public abstract class GSIRequestHandler
                              dhMessage.getContent());
                 break;
             default:
-                throw new RuntimeException("Unexpected bucketType in "
-                                                           + "finalizeSessionKey: "
-                                                           + bucketType.name());
+                throw new XrootdException(kGSErrCreateBucket, "Unexpected bucketType "
+                                                            + bucketType + " in "
+                                                            + "finalizeSessionKey: "
+                                                            + bucketType.name());
         }
 
         dhSession.finaliseKeyAgreement(dhMessage.getContent());
@@ -532,7 +533,7 @@ public abstract class GSIRequestHandler
                                          "signature of challenge tag has been "
                                          + "proven wrong!!",
                          challenge, rTagString);
-            throw new XrootdException(kXR_InvalidRequest,
+            throw new XrootdException(kGSErrBadRndmTag,
                                       "Sender did not present correct" +
                                                       "challenge response!");
         }
@@ -554,7 +555,7 @@ public abstract class GSIRequestHandler
                     InvalidKeyException
     {
         if (dhSession == null) {
-            throw new XrootdException(kXR_error, "trying to encrypt message "
+            throw new XrootdException(kXR_DecryptErr, "trying to encrypt message "
                             + "without session key.");
         }
 

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIServerRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIServerRequestHandler.java
@@ -43,8 +43,9 @@ import org.dcache.xrootd.security.StringBucket;
 import org.dcache.xrootd.security.XrootdBucket;
 import org.dcache.xrootd.security.XrootdSecurityProtocol.BucketType;
 
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ServerError;
 import static org.dcache.xrootd.security.XrootdSecurityProtocol.BucketType.*;
+import static org.dcache.xrootd.security.XrootdSecurityProtocol.kGSErrError;
+import static org.dcache.xrootd.security.XrootdSecurityProtocol.kGSErrInit;
 import static org.dcache.xrootd.security.XrootdSecurityProtocol.kXGS_cert;
 
 public abstract class GSIServerRequestHandler extends GSIRequestHandler
@@ -105,8 +106,8 @@ public abstract class GSIServerRequestHandler extends GSIRequestHandler
         } catch (GeneralSecurityException gssex) {
             LOGGER.error("Error setting up cryptographic classes: {}",
                          gssex.getMessage());
-            throw new XrootdException(kXR_ServerError,
-                                      "Server probably misconfigured.");
+            throw new XrootdException(kGSErrInit,
+                                      "dCache GSI module probably misconfigured.");
         }
     }
 
@@ -192,24 +193,21 @@ public abstract class GSIServerRequestHandler extends GSIRequestHandler
         } catch (InvalidKeyException ikex) {
             LOGGER.error("Configured host-key could not be used for " +
                                          "signing: {}", ikex.getMessage());
-            throw new XrootdException(kXR_ServerError,
-                                      "Internal error occurred when trying " +
-                                                      "to sign client authentication tag.");
+            throw new XrootdException(kGSErrError,
+                                      "Error when trying to sign client authentication tag.");
         } catch (CertificateEncodingException cee) {
             LOGGER.error("Could not extract contents of server certificate:" +
                                          " {}", cee.getMessage());
-            throw new XrootdException(kXR_ServerError,
-                                      "Internal error occurred when trying " +
-                                                      "to send server certificate.");
+            throw new XrootdException(kGSErrError,
+                                      "Error when trying to send server certificate.");
         } catch (IOException | GeneralSecurityException gssex) {
             LOGGER.error("Problems during signing of client authN tag " +
                                          "(algorithm {}): {}",
                          ASYNC_CIPHER_MODE,
                          gssex.getMessage() == null ?
                                          gssex.getClass().getName() : gssex.getMessage());
-            throw new XrootdException(kXR_ServerError,
-                                      "Internal error occurred when trying " +
-                                                      "to sign client authentication tag.");
+            throw new XrootdException(kGSErrError,
+                                      "Error when trying to sign client authentication tag.");
         }
     }
 

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/post49/GSIPost49ServerRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/post49/GSIPost49ServerRequestHandler.java
@@ -55,15 +55,11 @@ import org.dcache.xrootd.security.NestedBucketBuffer;
 import org.dcache.xrootd.security.StringBucket;
 import org.dcache.xrootd.security.UnsignedIntBucket;
 import org.dcache.xrootd.security.XrootdBucket;
-import org.dcache.xrootd.security.XrootdSecurityProtocol.BucketType;
+import org.dcache.xrootd.security.XrootdSecurityProtocol.*;
 
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_IOError;
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_InvalidRequest;
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ServerError;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_DecryptErr;
 import static org.dcache.xrootd.security.XrootdSecurityProtocol.BucketType.*;
-import static org.dcache.xrootd.security.XrootdSecurityProtocol.kXGC_cert;
-import static org.dcache.xrootd.security.XrootdSecurityProtocol.kXGC_sigpxy;
-import static org.dcache.xrootd.security.XrootdSecurityProtocol.kXGS_pxyreq;
+import static org.dcache.xrootd.security.XrootdSecurityProtocol.*;
 
 /**
  * Implementation of server side of GSI handshake according to XrootD 4.9+.
@@ -189,7 +185,7 @@ public class GSIPost49ServerRequestHandler extends GSIServerRequestHandler
             cancelHandshake();
             LOGGER.error("The key negotiated by DH key exchange appears to " +
                                          "be invalid: {}", ikex.getMessage());
-            throw new XrootdException(kXR_InvalidRequest,
+            throw new XrootdException(kXR_DecryptErr,
                                       "Could not decrypt client" +
                                                       "information with negotiated key.");
         } catch (IOException ioex) {
@@ -197,14 +193,14 @@ public class GSIPost49ServerRequestHandler extends GSIServerRequestHandler
             LOGGER.error("Could not deserialize main nested buffer {}",
                          ioex.getMessage() == null ?
                                          ioex.getClass().getName() : ioex.getMessage());
-            throw new XrootdException(kXR_IOError,
+            throw new XrootdException(kGSErrSerialBuffer,
                                       "Could not decrypt encrypted " +
                                                       "client message.");
         } catch (GeneralSecurityException gssex) {
             cancelHandshake();
             LOGGER.error("Error during decrypting/server-side key exchange: {}",
                          gssex.getMessage());
-            throw new XrootdException(kXR_ServerError,
+            throw new XrootdException(kGSErrError,
                                       "Error in server-side cryptographic " +
                                                       "operations.");
         }
@@ -255,7 +251,7 @@ public class GSIPost49ServerRequestHandler extends GSIServerRequestHandler
             cancelHandshake();
             LOGGER.error("The key negotiated by DH key exchange appears to " +
                                          "be invalid: {}", ikex.getMessage());
-            throw new XrootdException(kXR_InvalidRequest,
+            throw new XrootdException(kXR_DecryptErr,
                                       "Could not decrypt client" +
                                                       "information with negotiated key.");
         } catch (IOException ioex) {
@@ -263,14 +259,14 @@ public class GSIPost49ServerRequestHandler extends GSIServerRequestHandler
             LOGGER.error("Could not deserialize main nested buffer {}",
                          ioex.getMessage() == null ?
                                          ioex.getClass().getName() : ioex.getMessage());
-            throw new XrootdException(kXR_IOError,
+            throw new XrootdException(kGSErrSerialBuffer,
                                       "Could not decrypt encrypted " +
                                                       "client message.");
         } catch (GeneralSecurityException gssex) {
             cancelHandshake();
             LOGGER.error("Error during decrypting/server-side key exchange: {}",
                          gssex.getMessage());
-            throw new XrootdException(kXR_ServerError,
+            throw new XrootdException(kGSErrError,
                                       "Error in server-side cryptographic " +
                                                       "operations.");
         }

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/pre49/GSIPre49ServerRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/pre49/GSIPre49ServerRequestHandler.java
@@ -37,10 +37,10 @@ import org.dcache.xrootd.security.NestedBucketBuffer;
 import org.dcache.xrootd.security.XrootdBucket;
 import org.dcache.xrootd.security.XrootdSecurityProtocol.BucketType;
 
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_IOError;
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_InvalidRequest;
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ServerError;
+import static org.dcache.xrootd.protocol.XrootdProtocol.*;
 import static org.dcache.xrootd.security.XrootdSecurityProtocol.BucketType.kXRS_puk;
+import static org.dcache.xrootd.security.XrootdSecurityProtocol.kGSErrError;
+import static org.dcache.xrootd.security.XrootdSecurityProtocol.kGSErrSerialBuffer;
 import static org.dcache.xrootd.security.XrootdSecurityProtocol.kXGC_cert;
 
 /**
@@ -107,20 +107,20 @@ public class GSIPre49ServerRequestHandler extends GSIServerRequestHandler
         } catch (InvalidKeyException ikex) {
             LOGGER.error("The key negotiated by DH key exchange appears to " +
                                          "be invalid: {}", ikex.getMessage());
-            throw new XrootdException(kXR_InvalidRequest,
+            throw new XrootdException(kXR_DecryptErr,
                                       "Could not decrypt client" +
                                                       "information with negotiated key.");
          } catch (IOException ioex) {
             LOGGER.error("Could not deserialize main nested buffer {}",
                          ioex.getMessage() == null ?
                                          ioex.getClass().getName() : ioex.getMessage());
-            throw new XrootdException(kXR_IOError,
+            throw new XrootdException(kGSErrSerialBuffer,
                                       "Could not decrypt encrypted " +
                                                       "client message.");
         } catch (GeneralSecurityException gssex) {
             LOGGER.error("Error during decrypting/server-side key exchange: {}",
                          gssex.getMessage());
-            throw new XrootdException(kXR_ServerError,
+            throw new XrootdException(kXR_DecryptErr,
                                       "Error in server-side cryptographic " +
                                                       "operations.");
         }
@@ -133,7 +133,7 @@ public class GSIPre49ServerRequestHandler extends GSIServerRequestHandler
         /*
          *  Should not happen.
          */
-        throw new XrootdException(kXR_ServerError,
+        throw new XrootdException(kGSErrError,
                                   "proxy request signing step not supported.");
     }
 

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthorizationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthorizationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -327,14 +327,14 @@ public class XrootdAuthorizationHandler extends XrootdRequestHandler
                                      request.getRequestId(),
                                      neededPerm);
         } catch (GeneralSecurityException e) {
-            throw new XrootdException(kXR_ServerError,
+            throw new XrootdException(kXR_NotAuthorized,
                                       "Authorization check failed: " +
                                       e.getMessage());
         } catch (SecurityException e) {
             throw new XrootdException(kXR_NotAuthorized,
                                       "Permission denied: " + e.getMessage());
         } catch (ParseException e) {
-            throw new XrootdException(kXR_NotAuthorized,
+            throw new XrootdException(kXR_InvalidRequest,
                                       "Invalid opaque data: " + e.getMessage() +
                                       " (opaque=" + opaque + ")");
         }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/XrootdProtocol.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/XrootdProtocol.java
@@ -75,6 +75,10 @@ public interface XrootdProtocol {
     public static final int   kXR_ChkLenErr      = 3018;
     public static final int   kXR_ChkSumErr      = 3019;
     public static final int   kXR_inProgress     = 3020;
+    public static final int   kXR_overQuota      = 3021;
+    public static final int   kXR_SigVerErr      = 3022;
+    public static final int   kXR_DecryptErr     = 3023;
+    public static final int   kXR_Overloaded     = 3024;
     public static final int   kXR_noErrorYet     = 10000;
     @Deprecated // Kept for compatibility with plugins
     public static final int   kXR_FileLockedr    = 3003;

--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/SecurityInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/SecurityInfo.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 
 import org.dcache.xrootd.core.XrootdException;
 
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_error;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ArgMissing;
 
 /**
  * Utility class for holding security requirement information.
@@ -59,7 +59,7 @@ public class SecurityInfo
         }
 
         if (protocol.isEmpty()) {
-            throw new XrootdException(kXR_error, "Missing protocol name");
+            throw new XrootdException(kXR_ArgMissing, "Missing protocol name");
         }
     }
 
@@ -89,7 +89,7 @@ public class SecurityInfo
     {
         String value = data.get(key);
         if (value == null) {
-            throw new XrootdException(kXR_error, "missing '" + key + "' in sec");
+            throw new XrootdException(kXR_ArgMissing, "missing '" + key + "' in sec");
         }
         return value;
     }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientRequestHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientRequestHandler.java
@@ -333,7 +333,7 @@ public abstract class AbstractClientRequestHandler extends
                     doOnRedirectResponse(ctx,
                                          new InboundRedirectResponse(response));
                 } catch (ParseException e) {
-                    throw new XrootdException(kXR_ServerError,
+                    throw new XrootdException(kXR_InvalidRequest,
                                               "bad redirect data from kXR_asyncdi");
                 }
                 break;
@@ -351,11 +351,11 @@ public abstract class AbstractClientRequestHandler extends
                  *
                  * We do not issue prepare requests.  NR.
                  */
-                throw new XrootdException(kXR_ServerError,
+                throw new XrootdException(kXR_Unsupported,
                                           "tpc client does not support this option: "
                                            + response.getActnum());
             default:
-                throw new XrootdException(kXR_ServerError,
+                throw new XrootdException(kXR_ArgInvalid,
                                           "unrecognized kXR_attn action: "
                                            + response.getActnum());
         }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientSourceHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientSourceHandler.java
@@ -72,7 +72,7 @@ public abstract class AbstractClientSourceHandler extends
             String error = String.format("Authentication to %s failed; "
                             + "all protocols have been tried.",
                                          tpcInfo.getSrc());
-            throw new XrootdException(kXR_error, error);
+            throw new XrootdException(kXR_NotAuthorized, error);
         } else {
             LOGGER.debug("login of {} on {}, channel {}, stream {}, complete, "
                                          + "proceeding to open.",
@@ -152,7 +152,7 @@ public abstract class AbstractClientSourceHandler extends
                                              tpcInfo.getLfn(),
                                              tpcInfo.getSrc(),
                                              status);
-                throw new XrootdException(kXR_error, error);
+                throw new XrootdException(kXR_IOError, error);
         }
 
         client.setOpenFile(false);
@@ -187,7 +187,7 @@ public abstract class AbstractClientSourceHandler extends
                                          tpcInfo.getLfn(),
                                          tpcInfo.getSrc(),
                                          status);
-            throw new XrootdException(kXR_error, error);
+            throw new XrootdException(kXR_IOError, error);
         }
     }
 

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcClientConnectHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcClientConnectHandler.java
@@ -104,7 +104,7 @@ public class TpcClientConnectHandler extends
                             "Protocol request to %s failed with status %d.",
                             tpcInfo.getSrc(),
                             status);
-            throw new XrootdException(kXR_error, error);
+            throw new XrootdException(kXR_InvalidRequest, error);
         }
     }
 
@@ -166,7 +166,7 @@ public class TpcClientConnectHandler extends
             String error = String.format("Login to %s failed: status %d.",
                                          tpcInfo.getSrc(),
                                          status);
-            throw new XrootdException(kXR_error, error);
+            throw new XrootdException(kXR_InvalidRequest, error);
         }
     }
 

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSigverRequestEncoder.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSigverRequestEncoder.java
@@ -38,7 +38,7 @@ import org.dcache.xrootd.tpc.protocol.messages.AbstractXrootdOutboundRequest;
 import org.dcache.xrootd.tpc.protocol.messages.OutboundSigverRequest;
 import org.dcache.xrootd.tpc.protocol.messages.XrootdOutboundRequest;
 
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ServerError;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_DecryptErr;
 
 /**
  * <p>Checks to see if the protocol security context requires
@@ -121,7 +121,7 @@ public class TpcSigverRequestEncoder extends ChannelOutboundHandlerAdapter
                         BadPaddingException |
                         NoSuchProviderException |
                         IllegalBlockSizeException e) {
-            throw new XrootdException(kXR_ServerError, e.getMessage());
+            throw new XrootdException(kXR_DecryptErr, e.getMessage());
         }
     }
 }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
@@ -34,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.channels.ClosedChannelException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -44,6 +43,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.dcache.xrootd.core.XrootdException;
 import org.dcache.xrootd.core.XrootdSessionIdentifier;
 import org.dcache.xrootd.plugins.ChannelHandlerFactory;
 import org.dcache.xrootd.security.SigningPolicy;
@@ -54,6 +54,7 @@ import org.dcache.xrootd.tpc.protocol.messages.OutboundCloseRequest;
 import org.dcache.xrootd.tpc.protocol.messages.OutboundEndSessionRequest;
 import org.dcache.xrootd.tpc.protocol.messages.OutboundHandshakeRequest;
 import org.dcache.xrootd.util.OpaqueStringParser;
+import org.dcache.xrootd.util.ParseException;
 
 import static io.netty.channel.ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE;
 import static org.dcache.xrootd.protocol.XrootdProtocol.*;
@@ -512,14 +513,14 @@ public class XrootdTpcClient
     {
         error = t.getMessage();
 
-        if (t instanceof ClosedChannelException) {
-            errno = kXR_ServerError;
+        if (t instanceof XrootdException) {
+            errno = ((XrootdException)t).getError();
         } else if (t instanceof IOException) {
             errno = kXR_IOError;
-        } else if (t instanceof RuntimeException) {
-            errno = kXR_ServerError;
+        } else if (t instanceof ParseException) {
+            errno = kXR_ArgInvalid;
         } else {
-            errno = kXR_error;
+            errno = kXR_ServerError;
         }
 
         writeHandler.fireDelayedSync(errno, error);


### PR DESCRIPTION
Motivation:

Protocol 4.0 adds a few more error codes
which need to be incorporated.

But in general, the libary was in need
(as is the dcache-module) of review in terms
of its use of error codes.

Often, generic errors could be replaced by
more specific ones; but kXR_ServerError
should also not be abused, especially
in light of the fact that the client
may decide to retry when it receives
this error.  There were also instances
when the GS (security) errors subcodes
were more appropriate.

Modification:

Reviewed and adjusted as needed.

Result:

Hopefully a more meaningful response
to the XrootD client is returned.

Target: master
Request: 3.5
Patch: https://rb.dcache.org/r/11957
Acked-by: Tigran
Acked-by: Lea