### PR TITLE
xrootd4j: do not swallow opaque data when parsing the QueryRequest

### DIFF
--- a/xrootd4j-standalone/src/main/java/org/dcache/xrootd/standalone/DataServerHandler.java
+++ b/xrootd4j-standalone/src/main/java/org/dcache/xrootd/standalone/DataServerHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -509,7 +509,7 @@ public class DataServerHandler extends XrootdRequestHandler
 
         case kXR_Qcksum:
             try {
-                HashCode hash = com.google.common.io.Files.asByteSource(getFile(msg.getArgs())).hash(Hashing.adler32());
+                HashCode hash = com.google.common.io.Files.asByteSource(getFile(msg.getPath())).hash(Hashing.adler32());
                 return new QueryResponse(msg, "ADLER32 " + hash);
             } catch (FileNotFoundException e) {
                 throw new XrootdException(kXR_NotFound, e.getMessage());

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthorizationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthorizationHandler.java
@@ -258,18 +258,10 @@ public class XrootdAuthorizationHandler extends XrootdRequestHandler
         switch (req.getReqcode()) {
         case kXR_Qcksum:
         case kXR_Qxattr:
-            String args = req.getArgs();
-            int pos = args.indexOf(OPAQUE_DELIMITER);
-            String path;
-            String opaque;
-            if (pos > -1) {
-                path = args.substring(0, pos);
-                opaque = args.substring(pos + 1);
-            } else {
-                path = args;
-                opaque = "";
-            }
-            req.setArgs(authorize(ctx, req, FilePerm.READ, path, opaque));
+            req.setPath(authorize(ctx, req,
+                                  FilePerm.READ,
+                                  req.getPath(),
+                                  req.getOpaque()));
             break;
         }
         ctx.fireChannelRead(req);

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/ChecksumInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/ChecksumInfo.java
@@ -36,23 +36,20 @@ public class ChecksumInfo
     private final String           path;
     private final Optional<String> type;
 
-    public ChecksumInfo(String args) throws XrootdException
+    public ChecksumInfo(String path, String opaque) throws XrootdException
     {
-        int i = args.indexOf("?");
-        if (i == -1) {
-            path = args;
+        this.path = path;
+        if (opaque == null) {
             type = Optional.empty();
         } else {
-            path = args.substring(0, i);
-            String query = args.substring(i);
             try {
                 Map<String, String> map
-                                = OpaqueStringParser.getOpaqueMap(query);
+                                = OpaqueStringParser.getOpaqueMap(opaque);
                 type = Optional.ofNullable(map.get(KEY));
             } catch (ParseException e) {
                 throw new XrootdException(kXR_InvalidRequest,
                                           "malformed checksum query part: "
-                                                          + query);
+                                                          + opaque);
             }
         }
     }


### PR DESCRIPTION
Motivation:

The QueryRequest embraces a number of different
subtypes, two of which are actually Path queries.
As such, opaque data is possibly sent with
them.  In the case of the checksum query,
this opaque data actually specifies the
type of checksum requested.

Currently, this opaque data is being
swallowed when processed by the (NOOP)
authorization handler.

Modfication:

Put the parsing where it belongs
(inside the request) and expose
getters for path and opaque,
to be used where appropriate.

Modify the ChecksumInfo
constructor so the parsing
need not be redone.

Result:

The checksum type is now
available where before
it had disappeared.

Partial solution to GitHub issue https://github.com/dCache/dcache/issues/5147

Target: master
Request: 3.5
Request: 3.4
Request: 3.3
Patch: https://rb.dcache.org/r/12018
Bug:  dCache/dCache#5147
Acked-by: Paul