### PR TITLE
xrootd4j-gsi: prepend 0s stripped from CA cert md5 hash

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/CertUtil.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/CertUtil.java
@@ -240,8 +240,11 @@ public class CertUtil
                 | (0xff & md5hash[1]) << 8
                 | (0xff & md5hash[0]);
 
-            // convert to hex
-            principalHash = Integer.toHexString(shortHash);
+            /*
+             *  Convert to hex. An 8-digit hex string is required.
+             */
+            principalHash = String.format("%08x", shortHash);
+
             _hashCache.put(principal, principalHash);
         }
 


### PR DESCRIPTION
Motivation:

RT #9783] Questions regarding the token of the XRootD Door
draws attention to an as-yet undiscovered bug in the
way dCache computes the CA cert hash delivered to the
client by the door.

The openssl hash evidently required by xrootd should
be 8 digits in length (as are the CRLs in the standard
certificates directory).  The algorithm used, however,
finalizes the value by invoking Integer.toHexString,
which strips all leading zeros (e.g., ca:6769ccd instead
of ca:06769ccd.

In such cases, the xrootd client will reject the
server's hash as unrecognized.

Modification:

Use String.format to maintain an eight-digit hex
string.

Result:

Restored compatibility with the SLAC xrootd
implementation when cert hashes have leading
0's.

Target: master
Request: 3.5
Request: 3.4
Request: 3.3
Bug: https://rt.dcache.org/Ticket/Display.html?id=9783
Acked-by: Lea
Acked-by: Dmitry
Acked-by: Paul