### PR TITLE
xrootd4j: handle tpc.src URI correctly

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -552,10 +552,17 @@ public class XrootdTpcInfo {
             src = map.get(SRC);
         }
         if (src != null) {
-            String[] source = this.src.split(":");
-            this.srcHost = source[0];
+            /*
+             *  there may be a uname prefix, so remove it
+             */
+            int at = src.indexOf("@");
+            if (at >= 0) {
+                src = src.substring(at + 1);
+            }
+            String[] source = src.split(":");
+            srcHost = source[0];
             if (Strings.emptyToNull(source[1]) != null) {
-                this.srcPort = Integer.parseInt(source[1]);
+                srcPort = Integer.parseInt(source[1]);
             }
         }
     }


### PR DESCRIPTION
Motivation:

The embedded TPC client gets the source address from
the tpc.src URI in the opaque string query of the path.
This URI may contain the username prefix '<name>@', which
needs to be parsed out.  Currently the presence of
the uname is not being handled, causing failure to
connect.

Modification:

Strip away the uname prefix from the URI before using
it as endpoint hostname.

Result:

Giving dCache a source URL with username expressed for
TPC succeeds.

Target: master
Request: 3.5
Request: 3.4
Patch: https://rb.dcache.org/r/12225/
Acked-by: Dmitry