### PR TITLE
xrootd4j: handle incomplete source address

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
@@ -32,6 +32,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.dcache.xrootd.protocol.XrootdProtocol;
 import org.dcache.xrootd.tpc.protocol.messages.InboundRedirectResponse;
 import org.dcache.xrootd.util.OpaqueStringParser;
 import org.dcache.xrootd.util.ParseException;
@@ -529,8 +530,10 @@ public class XrootdTpcInfo {
             }
             String[] source = src.split(":");
             srcHost = source[0];
-            if (Strings.emptyToNull(source[1]) != null) {
+            if (source.length > 1 && Strings.emptyToNull(source[1]) != null) {
                 srcPort = Integer.parseInt(source[1]);
+            } else {
+                srcPort = XrootdProtocol.DEFAULT_PORT;
             }
         }
     }


### PR DESCRIPTION
Motivation:

The fix was incomplete, however.  The code is still
susceptible to missing port number.

Modfication:

Check for size of split array.  Provide default
port where none given.

Result:

No failure when host address contains no port.

Target: master
Request: 3.5
Request: 3.4
Patch: https://rb.dcache.org/r/12231/
Acked-by: Tigran