### PR TITLE
xrootd4j: validate usernames

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthorizationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthorizationHandler.java
@@ -327,8 +327,7 @@ public class XrootdAuthorizationHandler extends XrootdRequestHandler
                                       "Permission denied: " + e.getMessage());
         } catch (ParseException e) {
             throw new XrootdException(kXR_InvalidRequest,
-                                      "Invalid opaque data: " + e.getMessage() +
-                                      " (opaque=" + opaque + ")");
+                                      "Invalid opaque data: " + e.getMessage());
         }
     }
 }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/LoginRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/LoginRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -26,11 +26,12 @@ import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_useradmin;
 
 public class LoginRequest extends AbstractXrootdRequest
 {
-    private final String username;
     private final short role;
     private final short capver;
     private final int pid;
     private final String token;
+
+    private String username;
 
     public LoginRequest(ByteBuf buffer)
     {
@@ -55,6 +56,11 @@ public class LoginRequest extends AbstractXrootdRequest
     public String getUserName()
     {
         return username;
+    }
+
+    public void setUserName(String username)
+    {
+        this.username = username;
     }
 
     public boolean supportsAsyn()

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/OpaqueStringParser.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/OpaqueStringParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -23,6 +23,8 @@ import com.google.common.base.Joiner;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.dcache.xrootd.core.XrootdException;
 
 /**
  * According to the xrootd specification, an opaque string has the following
@@ -88,6 +90,12 @@ public class OpaqueStringParser {
         if (opaque == null || opaque.isEmpty()) {
             return Collections.emptyMap();
         } else {
+            try {
+                opaque = UserNameUtils.checkAllUsernamesValid(opaque);
+            } catch (XrootdException e) {
+                throw new ParseException(e.getMessage());
+            }
+
             Map<String,String> map = new HashMap<>();
 
             String [] prefixBlocks = opaque.split("\\?");

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/UserNameUtils.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/UserNameUtils.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ *
+ * This file is part of xrootd4j.
+ *
+ * xrootd4j is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * xrootd4j is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with xrootd4j.  If not, see http://www.gnu.org/licenses/.
+ */
+package org.dcache.xrootd.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.dcache.xrootd.core.XrootdException;
+
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ArgInvalid;
+
+/**
+ *  It is possible to confuse the OpaqueStringParser by introducing
+ *  Posix Non-Compliant UserNames.  This utility guards against
+ *  parser failure.
+ */
+public class UserNameUtils
+{
+    private static final String XROOTD_UNKNOWN_NAME = "????";
+    private static final String XROOTD_MAGIC_NAME = "_anon_";
+    private static final Pattern POSIX_COMPLIANT_UNAME
+                    = Pattern.compile("^[a-z_][a-z0-9_-]*[$]?$",
+                                      Pattern.CASE_INSENSITIVE);
+    private static final Pattern UNAME_SLOT = Pattern.compile("[=]([^@=]+)[@]");
+
+    /**
+     * Checks for POSIX compliance.  Rejects <code>null</code> names but
+     * accepts zero-length names.  If the name equals "????" it returns
+     * "_anon_"; if the name is otherwise invalid, it throws an exception;
+     * else it returns the name unchanged.
+     *
+     * @param username to validate.
+     * @return "_anon_" if "????", or the valid name.
+     * @throws XrootdException if the name is invalid.
+     */
+    public static String checkUsernameValid(String username)
+                    throws XrootdException
+    {
+        if (XROOTD_UNKNOWN_NAME.equals(username)) {
+            return XROOTD_MAGIC_NAME;
+        }
+
+        if (username == null
+                        || (!username.isEmpty()
+                        && !POSIX_COMPLIANT_UNAME.matcher(username).matches())) {
+            throw new XrootdException(kXR_ArgInvalid, "Bad user name.");
+        }
+
+        return username;
+    }
+
+    /**
+     * Finds all segments/groups of the string which could potentially be
+     * usernames (bounded by '=' and '@'), and checks each for validity.
+     * If the Xrootd Unknown marker is found ('????') it is replaced by
+     * ('_anon_').  If an invalid name is found in the string, the check
+     * fails.  Otherwise, the valid names are left as they are.
+     *
+     * @param string original string to validate.
+     * @return string with "magic" substitutions, if any.
+     * @throws XrootdException if any name found in the string is invalid.
+     */
+    public static String checkAllUsernamesValid(String string)
+                    throws XrootdException
+    {
+        StringBuilder builder = new StringBuilder();
+        int from = 0;
+        int to;
+
+        Matcher matcher = UNAME_SLOT.matcher(string);
+
+        while (matcher.find())
+        {
+            String group = matcher.group(1);
+            to = string.indexOf(group, from);
+            builder.append(string.substring(from, to));
+            String[] unamepid = group.split("[.]");
+            if (unamepid.length > 2) {
+                throw new XrootdException(kXR_ArgInvalid, "Bad user name.");
+            }
+            from = to + unamepid[0].length();
+            String valid = checkUsernameValid(unamepid[0]);
+            builder.append(valid);
+            if (unamepid.length == 2) {
+                try {
+                    Long.parseLong(unamepid[1]);
+                } catch (NumberFormatException e) {
+                    throw new XrootdException(kXR_ArgInvalid,
+                                              "Bad pid following user name.");
+                }
+                builder.append(".").append(unamepid[1]);
+                from = from + unamepid[1].length() + 1;
+            }
+        }
+
+        if (from < string.length()) {
+            builder.append(string.substring(from));
+        }
+
+        return builder.toString();
+    }
+}

--- a/xrootd4j/src/test/java/org/dcache/xrootd/util/UserNameUtilsTest.java
+++ b/xrootd4j/src/test/java/org/dcache/xrootd/util/UserNameUtilsTest.java
@@ -1,0 +1,241 @@
+/**
+ * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ *
+ * This file is part of xrootd4j.
+ *
+ * xrootd4j is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * xrootd4j is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with xrootd4j.  If not, see http://www.gnu.org/licenses/.
+ */
+package org.dcache.xrootd.util;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.dcache.xrootd.core.XrootdException;
+
+import static org.dcache.xrootd.util.OpaqueStringParser.OPAQUE_STRING_PREFIX;
+import static org.junit.Assert.assertEquals;
+
+/**
+ *  Tests checks for Posix compliance of user names, and for
+ *  replacement of non-compliant names in strings.
+ */
+public class UserNameUtilsTest
+{
+    private static final String TPC_SRC = "tpc.src";
+    private static final String TPC_DLG = "tpc.dlg";
+    private static final String CLIENT = "org.dcache.xrootd.client";
+    private static final String OSS_ASIZE = "oss.asize";
+    private static final String TPC_KEY = "tpc.key";
+    private static final String TPC_LFN = "tpc.lfn";
+    private static final String TPC_SPR = "tpc.spr";
+    private static final String TPC_TPR = "tpc.tpr";
+    private static final String TPC_STAGE = "tpc.stage";
+    private static final String TPC_STR = "tpc.str";
+    private static final String MOVER_UUID = "org.dcache.uuid";
+
+    private static final String XROOTD_UNKNOWN_TPC_SRC = "????@foobar.org";
+    private static final String XROOTD_UNKNOWN_TPC_DLG = "????@foobar.org";
+    private static final String XROOTD_UNKNOWN_CLIENT = "????.29931@foobar.org";
+
+    private static final String NON_COMPLIANT_CLIENT = "i&v4.29931@foobar.org";
+    private static final String NON_COMPLIANT_SRC = "alrossi7&@foobar.org";
+    private static final String NON_COMPLIANT_PID = "foo.29a31@foobar.org";
+    private static final String NON_COMPLIANT_PID_2 = "foo.bar.29931@foobar.org";
+
+    private static final String COMPLIANT_TPC_SRC = "arossi2020@foobar.org";
+    private static final String COMPLIANT_TPC_DLG = "arossi2020@foobar.org";
+    private static final String COMPLIANT_CLIENT = "arossi2020.29931@foobar.org";
+
+    private static final String REPLACED_TPC_SRC = "_anon_@foobar.org";
+    private static final String REPLACED_TPC_DLG = "_anon_@foobar.org";
+    private static final String REPLACED_CLIENT = "_anon_.29931@foobar.org";
+
+    private static final String KEY_VAL = UUID.randomUUID().toString();
+    private static final String ASIZE_VAL = "2048";
+    private static final String LFN_VAL = "/pnfs/fs/usr/test/arossi/volatile/testdata";
+    private static final String SPR_VAL = "root";
+    private static final String TPR_VAL = "root";
+    private static final String STAGE_VAL = "copy";
+    private static final String STR_VAL = "1";
+    private static final String UUID_VAL = UUID.randomUUID().toString();
+
+    private String opaqueString;
+    private Map<String, String> parsed;
+
+    @Test
+    public void shouldAcceptEmptyUserName() throws Exception
+    {
+        assertEquals("Should have accepted empty name", "",
+                   UserNameUtils.checkUsernameValid(""));
+    }
+
+    @Test( expected=XrootdException.class)
+    public void shouldNotAcceptNullUserName() throws Exception
+    {
+        UserNameUtils.checkUsernameValid(null);
+    }
+
+    @Test
+    public void shouldAcceptCompliantUserName() throws Exception
+    {
+        assertEquals("Should have accepted user name.",
+                     "a_l_rossi1955-06-01",
+                   UserNameUtils.checkUsernameValid("a_l_rossi1955-06-01"));
+    }
+
+    @Test
+    public void shouldAcceptUserNameThatBeginsWithUpperCaseLetter() throws Exception
+    {
+        assertEquals("Should have accepted user name.",
+                     "A_l_rossi1955-06-01",
+        UserNameUtils.checkUsernameValid("A_l_rossi1955-06-01"));
+    }
+
+    @Test( expected=XrootdException.class)
+    public void shouldNotAcceptUserNameThatBeginsWithNumber() throws Exception
+    {
+        UserNameUtils.checkUsernameValid("7a_l_rossi1955-06-01");
+    }
+
+    @Test( expected=XrootdException.class)
+    public void shouldNotAcceptUserNameThatContainsUpperCaseLetter() throws Exception
+    {
+        UserNameUtils.checkUsernameValid("a_l_Rossi?1955-06-01");
+    }
+
+    @Test( expected=XrootdException.class)
+    public void shouldNotAcceptUserNameThatContainsSpecialCharacters() throws Exception
+    {
+        UserNameUtils.checkUsernameValid("7a_l_rossi?1955-06-01");
+    }
+
+    @Test
+    public void shouldChangeUnknownToMagicNameForAllUsernames() throws Exception
+    {
+        givenOpaqueStringWithXrootdUnknownNames();
+        whenStringIsParsed();
+        assertThatXrootdUnknownNamesAreReplaced();
+    }
+
+    @Test
+    public void shouldNotReplaceCompliantUsernames() throws Exception
+    {
+        givenOpaqueStringWithClientName(COMPLIANT_CLIENT);
+        whenStringIsParsed();
+        assertThatCompliantNamesAreUnchanged();
+    }
+
+    @Test( expected=ParseException.class)
+    public void shouldFailIfClientContainsNonCompliantUsername() throws Exception
+    {
+        givenOpaqueStringWithClientName(NON_COMPLIANT_CLIENT);
+        whenStringIsParsed();
+    }
+
+    @Test( expected=ParseException.class)
+    public void shouldFailIfSrcContainsNonCompliantUsername() throws Exception
+    {
+        givenOpaqueStringWithSrcName(NON_COMPLIANT_SRC);
+        whenStringIsParsed();
+    }
+
+    @Test( expected=ParseException.class)
+    public void shouldFailIfClientContainsNonCompliantPid() throws Exception
+    {
+        givenOpaqueStringWithClientName(NON_COMPLIANT_PID);
+        whenStringIsParsed();
+    }
+
+    @Test( expected=ParseException.class)
+    public void shouldFailIfClientContainsDoublePeriod() throws Exception
+    {
+        givenOpaqueStringWithClientName(NON_COMPLIANT_PID_2);
+        whenStringIsParsed();
+    }
+
+    private void whenStringIsParsed() throws Exception
+    {
+        parsed = OpaqueStringParser.getOpaqueMap(opaqueString);
+    }
+
+    private void assertThatCompliantNamesAreUnchanged() throws Exception
+    {
+        assertEquals("Wrong " + TPC_SRC + " value",
+                     COMPLIANT_TPC_SRC, parsed.get(TPC_SRC));
+        assertEquals("Wrong " + TPC_DLG + " value",
+                     COMPLIANT_TPC_DLG, parsed.get(TPC_DLG));
+        assertEquals("Wrong " + CLIENT + " value",
+                     COMPLIANT_CLIENT, parsed.get(CLIENT));
+    }
+
+    private void assertThatXrootdUnknownNamesAreReplaced() throws Exception
+    {
+        assertEquals("Wrong " + TPC_SRC + " value",
+                     REPLACED_TPC_SRC, parsed.get(TPC_SRC));
+        assertEquals("Wrong " + TPC_DLG + " value",
+                     REPLACED_TPC_DLG, parsed.get(TPC_DLG));
+        assertEquals("Wrong " + CLIENT + " value",
+                     REPLACED_CLIENT, parsed.get(CLIENT));
+    }
+
+    private void givenOpaqueStringWithXrootdUnknownNames()
+    {
+        Map<String, String> opaqueMap = new HashMap<>();
+        opaqueMap.put(TPC_SRC, XROOTD_UNKNOWN_TPC_SRC);
+        opaqueMap.put(TPC_DLG, XROOTD_UNKNOWN_TPC_DLG);
+        opaqueMap.put(CLIENT, XROOTD_UNKNOWN_CLIENT);
+        addOtherValues(opaqueMap);
+        opaqueString = OPAQUE_STRING_PREFIX + OpaqueStringParser.buildOpaqueString(opaqueMap);
+    }
+
+    private void givenOpaqueStringWithClientName(String name)
+    {
+        Map<String, String> opaqueMap = new HashMap<>();
+        opaqueMap.put(TPC_SRC, COMPLIANT_TPC_SRC);
+        opaqueMap.put(TPC_DLG, COMPLIANT_TPC_DLG);
+        add(CLIENT, name, opaqueMap);
+        addOtherValues(opaqueMap);
+        opaqueString = OPAQUE_STRING_PREFIX + OpaqueStringParser.buildOpaqueString(opaqueMap);
+    }
+
+    private void givenOpaqueStringWithSrcName(String name)
+    {
+        Map<String, String> opaqueMap = new HashMap<>();
+        add(TPC_SRC, name, opaqueMap);
+        opaqueMap.put(TPC_DLG, COMPLIANT_TPC_DLG);
+        opaqueMap.put(CLIENT, COMPLIANT_CLIENT);
+        addOtherValues(opaqueMap);
+        opaqueString = OPAQUE_STRING_PREFIX + OpaqueStringParser.buildOpaqueString(opaqueMap);
+    }
+
+    private void add(String name, String value, Map<String, String> opaqueMap)
+    {
+        opaqueMap.put(name, value);
+    }
+
+    private void addOtherValues(Map<String, String> opaqueMap)
+    {
+        opaqueMap.put(OSS_ASIZE, ASIZE_VAL);
+        opaqueMap.put(TPC_KEY, KEY_VAL);
+        opaqueMap.put(TPC_LFN, LFN_VAL);
+        opaqueMap.put(TPC_SPR, SPR_VAL);
+        opaqueMap.put(TPC_TPR, TPR_VAL);
+        opaqueMap.put(TPC_STAGE, STAGE_VAL);
+        opaqueMap.put(TPC_STR, STR_VAL);
+        opaqueMap.put(MOVER_UUID, UUID_VAL);
+    }
+}


### PR DESCRIPTION
Motivation:

In moving from dCache 2.13 to 5.2, the
following error occurs sporadically on
the CMS disk instance at FNAL:

level=ERROR ts=2020-02-14T16:19:55.689-0600 event=org.dcache.xrootd.request sess
ion=pool:w-cmsstor265-disk-disk1@w-cmsstor265-disk-disk1Domain:xrootd:8742e0ff r
equest=open path=/store/mc/RunIIFall17NanoAODv6/QCD_HT300to500_BGenFilter_TuneCP
5_13TeV-madgraph-pythia8/NANOAODSIM/PU2017_12Apr2018_Nano25Oct2019_102X_mc2017_r
ealistic_v7-v1/260000/2D9370AF-4063-374C-87B1-B334E26BC136.root opaque=org.dcach
e.xrootd.client= mode=0 options=0x440 response=error error.code=NotAuhorized err
or.msg="Request lacks the org.dcache.uuid property."

This results from a rather obscure environment
where the username comes up undefined.  In this
case, xrdcp logs in using "????".  Since 5.0 (as
a consequence of TPC), there are some new URIs
being passed as part of the opaque data, however,
and the presence of "????" causes a parsing
error and truncation of the string, so that dCache
cannot complete the path request (in particular,
the mover UUID is missing).

Modification:

The solution here is two pronged.  First, we check
all usernames to see if they equal the xrootd
"unknown user" (????), and if so, convert them to
"anon".  Otherwise, if the names are not
POSIX-compliant, we throw an exception.

Names are checked at login, but the path query
string is also scanned, with the same
replacement/rejection logic in force.

A utility class for handling usernames is added,
along with unit tests. Note that names which contain
@ or = still will cause parse errors as
those characters delimit a potential username
in the string.

Result:

More robust handling of irregular usernames.

Target: master
Request: 3.5
Request: 3.4
Patch: https://rb.dcache.org/r/12233
Acked-by: Tigran