### PR TITLE
xrootd4j: modifications to support xrootd.tls tpc and tpc.spr=xroots

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
@@ -65,19 +65,15 @@ public class XrootdTpcInfo {
 
     public static final String SIZE_IN_BYTES = "oss.asize";
 
-    /**
-     * This is provisional.  REVISIT when protocol finalized
-     */
-    public static final String TLS = "tpc.tls";
-
-    /*
-     * Unused, but these need to be eliminated from
-     * the path if delegation is supported.
-     */
     public static final String STR = "tpc.str";
 
     public static final String TPR = "tpc.tpr";
 
+    /**
+     *  This protocol should be used in conjunction with
+     *  server-side settings to determine whether the
+     *  TPC client should use TLS (= 'xroots').
+     */
     public static final String SPR = "tpc.spr";
 
     /**
@@ -106,8 +102,7 @@ public class XrootdTpcInfo {
                                       STR,
                                       DLG,
                                       TPR,
-                                      SPR,
-                                      TLS);
+                                      SPR);
 
     public enum Status
     {
@@ -596,7 +591,7 @@ public class XrootdTpcInfo {
 
     private void setTlsFromOpaque(Map<String, String> map)
     {
-        String tlsString = map.get(TLS);
-        this.tls = "1".equals(tlsString);
+        String tlsString = map.get(SPR);
+        tls = "xroots".equals(tlsString);
     }
 }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/ServerProtocolFlags.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/ServerProtocolFlags.java
@@ -42,7 +42,8 @@ import static org.dcache.xrootd.util.ServerProtocolFlags.TlsMode.STRICT;
  */
 public class ServerProtocolFlags
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ServerProtocolFlags.class);
+    private static final Logger LOGGER
+                    = LoggerFactory.getLogger(ServerProtocolFlags.class);
 
     public enum TlsMode
     {
@@ -57,15 +58,23 @@ public class ServerProtocolFlags
     {
     }
 
+    /**
+     * Constructor used in conjunction with flags from remote (source)
+     * server.
+     *
+     * @param flags received with protocol response.
+     */
     public ServerProtocolFlags(int flags)
     {
         this.flags = flags;
-        mode = STRICT;
         if (!requiresTLSForData() &&
                         !requiresTLSForGPF() &&
                         !requiresTLSForLogin() &&
-                        !requiresTLSForSession()) {
+                        !requiresTLSForSession() &&
+                        !requiresTLSForTPC()) {
             mode = OFF;
+        } else {
+            mode = STRICT;
         }
     }
 
@@ -157,29 +166,36 @@ public class ServerProtocolFlags
 
     public boolean requiresTLSForData()
     {
-        boolean response = mode != OFF && (flags & kXR_tlsData) == kXR_tlsData;
+        boolean response = (flags & kXR_tlsData) == kXR_tlsData;
         LOGGER.trace("requiresTLSForData ? {}.", response);
         return response;
     }
 
     public boolean requiresTLSForGPF()
     {
-        boolean response = mode != OFF && (flags & kXR_tlsGPF) == kXR_tlsGPF;
+        boolean response = (flags & kXR_tlsGPF) == kXR_tlsGPF;
         LOGGER.trace("requiresTLSForLogin ? {}.", response);
         return response;
     }
 
     public boolean requiresTLSForLogin()
     {
-        boolean response = mode != OFF && (flags & kXR_tlsLogin) == kXR_tlsLogin;
+        boolean response = (flags & kXR_tlsLogin) == kXR_tlsLogin;
         LOGGER.trace("requiresTLSForLogin ? {}.", response);
         return response;
     }
 
     public boolean requiresTLSForSession()
     {
-        boolean response = mode != OFF && (flags & kXR_tlsSess) == kXR_tlsSess;
+        boolean response = (flags & kXR_tlsSess) == kXR_tlsSess;
         LOGGER.trace("requiresTLSForSession ? {}.", response);
+        return response;
+    }
+
+    public boolean requiresTLSForTPC()
+    {
+        boolean response = (flags & kXR_tlsTPC) == kXR_tlsTPC;
+        LOGGER.trace("requiresTLSForTPC ? {}.", response);
         return response;
     }
 
@@ -299,6 +315,16 @@ public class ServerProtocolFlags
         }
     }
 
+    public void setRequiresTLSForTPC(boolean value)
+    {
+        LOGGER.trace("setRequiresTLSForSession {}.", value);
+        if (value) {
+            flags |= kXR_tlsTPC;
+        } else {
+            flags &= (~kXR_tlsTPC);
+        }
+    }
+
     public void setServerRole(boolean value)
     {
         LOGGER.trace("setServerRole {}.", value);
@@ -401,22 +427,24 @@ public class ServerProtocolFlags
                                         + "tlsGPF %s, "
                                         + "tlsLogin %s, "
                                         + "tlsSession %s, "
+                                        + "tlsTPC %s, "
                                         + "goToTLS %s, "
                                         + "anonGPF %s)",
-                        mode,
-                        getFlags(),
-                        hasManagerRole(),
-                        hasMetaServerRole(),
-                        hasProxyServerRole(),
-                        hasServerRole(),
-                        hasSupervisorRole(),
-                        isDataServer(),
-                        isLoadBalancingServer(),
-                        requiresTLSForData(),
-                        requiresTLSForGPF(),
-                        requiresTLSForLogin(),
-                        requiresTLSForSession(),
-                        goToTLS(),
-                        allowsAnonymousGPFile());
+                             mode,
+                             getFlags(),
+                             hasManagerRole(),
+                             hasMetaServerRole(),
+                             hasProxyServerRole(),
+                             hasServerRole(),
+                             hasSupervisorRole(),
+                             isDataServer(),
+                             isLoadBalancingServer(),
+                             requiresTLSForData(),
+                             requiresTLSForGPF(),
+                             requiresTLSForLogin(),
+                             requiresTLSForSession(),
+                             requiresTLSForTPC(),
+                             goToTLS(),
+                             allowsAnonymousGPFile());
     }
 }


### PR DESCRIPTION
Motivation:

In the initial implementation of TLS, the "requires TPC" option
was left out of the server protocol options because it was
unclear how this was to work.

This has now been clarified as follows:  "requires TPC" (the
equivalent of xrootd.tls tpc) means that the destination
server will block any clients which do not support TLS
(i.e., pre-version-5) from requesting TPC.  The TPC
requirement, however, is not sufficient to activate
TLS on the third-party connection.  That is determined
by two factors:  (a) the protocol expressed by the
client in connecting to the source server (xroots vs
xroot), and (b) what the source server actually
requires.   If (a) is 'xroots' and both source
and destination have TLS, it is used; else
the TPC should fail.  If it is 'xroot', then
the source server determines the TLS requirement.

Modification:

The flag is added to the server protocol.  A small
modification in how the requirement values are
verified allows distinguishing between whether
TPC is set and whether the server actually
requires TLS.  The TPC flag is checked in
the appropriate places against the incoming
client flags.

tpc.spr (source protocol) is now accessed
to determine whether the TPC client should
advertise itself as "wantTls" or "ableTls".

Some debugging statments have been
added and some trace-level promoted to
debug-level.

Result:

We now should behave like the vanilla
xrootd implementation with regard to
enforcement of TLS on the TPC connection.

Target: master
Patch: https://rb.dcache.org/r/12305
Request: 4.0.0
Acked-by: Tigran