### PR TITLE
Author: Albert Louis Rossi <arossi@fnal.gov>

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthorizationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthorizationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdSigverDecoder.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdSigverDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -113,7 +113,7 @@ public class XrootdSigverDecoder extends AbstractXrootdDecoder
 
             int requestId = request.getRequestId();
 
-            if (signingPolicy.requiresSigning(requestId)) {
+            if (signingPolicy.requiresSigning(request)) {
                 verifySignedHash(request.getStreamId(),
                                  requestId,
                                  frame,

--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/SigningPolicy.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/SigningPolicy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -23,6 +23,11 @@ import io.netty.buffer.ByteBuf;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
+
+import org.dcache.xrootd.protocol.messages.OpenRequest;
+import org.dcache.xrootd.protocol.messages.XrootdRequest;
+import org.dcache.xrootd.tpc.protocol.messages.AbstractXrootdOutboundRequest;
+import org.dcache.xrootd.tpc.protocol.messages.OutboundOpenReadOnlyRequest;
 
 import static org.dcache.xrootd.protocol.XrootdProtocol.*;
 import static org.dcache.xrootd.security.XrootdSecurityProtocol.*;
@@ -72,7 +77,45 @@ public class SigningPolicy
         return secLvl > kXR_secNone;
     }
 
-    public boolean requiresSigning(int requestId)
+    public boolean requiresSigning(XrootdRequest request)
+    {
+        int requestId = request.getRequestId();
+        boolean readOnly = requestId == kXR_open &&
+                        ((OpenRequest)request).isReadOnly();
+        return requiresSigning(requestId, readOnly);
+    }
+
+    public boolean requiresSigning(AbstractXrootdOutboundRequest request)
+    {
+        boolean readOnly = request instanceof OutboundOpenReadOnlyRequest;
+        return requiresSigning(request.getRequestId(), readOnly);
+    }
+
+    public String toString()
+    {
+        return "(secLvl " + secLvl
+                        + ")(overrides " + overrides
+                        + ")(force " + isForceSigning() + ")";
+    }
+
+    public void writeBytes(ByteBuf buffer)
+    {
+        buffer.writeByte(secOFrce);
+        buffer.writeByte(secLvl);
+
+        /*
+         * kXR_char secvsz = length of data array, that is, size of map
+         * {kXR_char,kXR_char} [reqidx,reqlvl]
+         */
+        buffer.writeByte(overrides.size());
+
+        for (Entry<Integer,Integer> entry : overrides.entrySet()) {
+            buffer.writeByte(entry.getKey());
+            buffer.writeByte(entry.getValue());
+        }
+    }
+
+    private boolean requiresSigning(int requestId, boolean readOnly)
     {
         int signingLevel;
         Integer override =  overrides.get(requestId);
@@ -92,17 +135,29 @@ public class SigningPolicy
             case kXR_sync:
                 signingLevel = kXR_secPedantic;
                 break;
+            case kXR_bind:
             case kXR_close:
             case kXR_endsess:
+            case kXR_set:
             case kXR_write:
                 signingLevel = kXR_secIntense;
                 break;
             case kXR_mkdir:
+                signingLevel = kXR_secStandard;
+                break;
             case kXR_open:
+                if (readOnly) {
+                    signingLevel = kXR_secStandard;
+                } else {
+                    signingLevel = kXR_secCompatible;
+                }
+                break;
+            case kXR_auth:
+            case kXR_chmod:
             case kXR_mv:
             case kXR_rmdir:
             case kXR_rm:
-            case kXR_set:
+            case kXR_truncate:
                 signingLevel = kXR_secCompatible;
                 break;
             default:
@@ -111,28 +166,5 @@ public class SigningPolicy
 
         return signingLevel != kXR_secNone &&
                         (secLvl >= signingLevel || override == kXR_signNeeded);
-    }
-
-    public String toString()
-    {
-        return "(secLvl " + secLvl
-                        + ")(overrides " + overrides
-                        + ")(force " + isForceSigning() + ")";
-    }
-
-    public void writeBytes(ByteBuf buffer)
-    {
-        buffer.writeByte(secOFrce);
-        buffer.writeByte(secLvl);
-        /*
-         * kXR_char secvsz = length of data array, that is, size of map
-         * {kXR_char,kXR_char} [reqidx,reqlvl]
-         */
-        buffer.writeByte(overrides.size());
-
-        for (Entry<Integer,Integer> entry : overrides.entrySet()) {
-            buffer.writeByte(entry.getKey());
-            buffer.writeByte(entry.getValue());
-        }
     }
 }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSigverRequestEncoder.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSigverRequestEncoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -98,7 +98,7 @@ public class TpcSigverRequestEncoder extends ChannelOutboundHandlerAdapter
         AbstractXrootdOutboundRequest abstractRequest
                         = (AbstractXrootdOutboundRequest) request;
 
-        if (!signingLevel.requiresSigning(abstractRequest.getRequestId())) {
+        if (!signingLevel.requiresSigning(abstractRequest)) {
             return null;
         }
 


### PR DESCRIPTION
Date:   Mon Apr 20 08:05:10 2020 -0500

xrootd4j: update and fix compatible level security for sigver

        Motivation:

        The compatible (=1) level for xrootd security requires
        signed hash verification on open only if it is for write.
        Currently, the server is requiring it for all open
        calls, including read only (the TPC client, on the
        other hand, only does read only opens and thus
        will behave correctly against the source).

        Modification:

        Modify the SecurityLevel processing to account
        for the difference between open read-write and
        open read.

        The security level settings in general are reviewed
        and updated/corrected where needed.

        Result:

        dCache will not erroneously force the xroot client
        (esp. TPC client) to send signed hashes on open
        for read only when it advertises its security level
        as "compatible".

        Target: master
        Request: 4.0
        Request: 3.5
        Request: 3.4 ?
        Patch:  https://rb.dcache.org/r/12321/
        Requires-notes:  yes
        Requires-book: no
        Acked-by: Tigran