### PR TITLE
xrootd4j: remove kXR_auth from signed hash compatible

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/SigningPolicy.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/SigningPolicy.java
@@ -154,7 +154,6 @@ public class SigningPolicy
                     signingLevel = kXR_secCompatible;
                 }
                 break;
-            case kXR_auth:
             case kXR_chkpoint:
             case kXR_chmod:
             case kXR_fattr:


### PR DESCRIPTION
Motivation:

Patch:  https://rb.dcache.org/r/12321/
Committed: master@0406002401d73d39a9b43f48ee769637cabd76b6

accidentally included kXR_auth under the compatible security
level.  Signed hashes are not required for anything
up to and including authentication.   This was a copy-paste
error.

Modfication:

Remove it.

Result:

Compatible level works on the pools where it was failing
because the sigver decoder is added at login.

Target: master
Request: 4.0
Request: 3.5
Request: 3.4
Acked-by: Paul
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12330/