### PR TITLE
xrootd4j: loosen validation of username 'pid'

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -82,6 +83,18 @@ public class XrootdTpcClient
     private static final int DEFAULT_RESPONSE_TIMEOUT_IN_SECONDS = 30;
 
     private static int lastId = 1;
+
+    /**
+     * The pid is used for monitoring purposes on the xrootd end.
+     * In order to imitate xrootd, which execs the TPC client,
+     * we just generate a random five-digit number here.
+     *
+     * @return "pid" for the TPC client
+     */
+    private static synchronized int getClientPid()
+    {
+        return ThreadLocalRandom.current().nextInt(99999);
+    }
 
     /**
      *  Stream value of 0 is reserved for initial handshakes.
@@ -178,14 +191,14 @@ public class XrootdTpcClient
         String[] userSplit = user.split("[.]");
 
         /*
-         *  Reuse the original uname and pid
+         *  Reuse the original uname
          *  when sending to the source server.
          *
          *  Thus the source will see the client contact as uname.pid@clienthost
          *  and the dCache pool contact as uname.pid@poolhost.
          */
         uname = userSplit[0];
-        pid = Integer.parseInt(userSplit[1]);
+        pid = getClientPid();
         writeOffset = 0L;
         errno = kXR_ok;
         redirects = 0;

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/UserNameUtils.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/UserNameUtils.java
@@ -94,16 +94,13 @@ public class UserNameUtils
             if (unamepid.length > 2) {
                 throw new XrootdException(kXR_ArgInvalid, "Bad user name.");
             }
+            /*
+             *  POSIX-validate only the part of the name up to a period.
+             */
             from = to + unamepid[0].length();
             String valid = checkUsernameValid(unamepid[0]);
             builder.append(valid);
             if (unamepid.length == 2) {
-                try {
-                    Long.parseLong(unamepid[1]);
-                } catch (NumberFormatException e) {
-                    throw new XrootdException(kXR_ArgInvalid,
-                                              "Bad pid following user name.");
-                }
                 builder.append(".").append(unamepid[1]);
                 from = from + unamepid[1].length() + 1;
             }

--- a/xrootd4j/src/test/java/org/dcache/xrootd/util/UserNameUtilsTest.java
+++ b/xrootd4j/src/test/java/org/dcache/xrootd/util/UserNameUtilsTest.java
@@ -53,8 +53,8 @@ public class UserNameUtilsTest
 
     private static final String NON_COMPLIANT_CLIENT = "i&v4.29931@foobar.org";
     private static final String NON_COMPLIANT_SRC = "alrossi7&@foobar.org";
-    private static final String NON_COMPLIANT_PID = "foo.29a31@foobar.org";
     private static final String NON_COMPLIANT_PID_2 = "foo.bar.29931@foobar.org";
+    private static final String EXTENDED_PID        = "foo.29042:10@foobar.org";
 
     private static final String COMPLIANT_TPC_SRC = "arossi2020@foobar.org";
     private static final String COMPLIANT_TPC_DLG = "arossi2020@foobar.org";
@@ -105,6 +105,13 @@ public class UserNameUtilsTest
         UserNameUtils.checkUsernameValid("A_l_rossi1955-06-01"));
     }
 
+    @Test
+    public void shouldNotFailIfClientContainsExtendedPid() throws Exception
+    {
+        givenOpaqueStringWithClientName(EXTENDED_PID);
+        whenStringIsParsed();
+    }
+
     @Test( expected=XrootdException.class)
     public void shouldNotAcceptUserNameThatBeginsWithNumber() throws Exception
     {
@@ -150,13 +157,6 @@ public class UserNameUtilsTest
     public void shouldFailIfSrcContainsNonCompliantUsername() throws Exception
     {
         givenOpaqueStringWithSrcName(NON_COMPLIANT_SRC);
-        whenStringIsParsed();
-    }
-
-    @Test( expected=ParseException.class)
-    public void shouldFailIfClientContainsNonCompliantPid() throws Exception
-    {
-        givenOpaqueStringWithClientName(NON_COMPLIANT_PID);
         whenStringIsParsed();
     }
 


### PR DESCRIPTION
Motivation:

https://rb.dcache.org/r/12234
master@4df20da279b6f8777c3c2ef10619cb44f98cbcc0

introduced username validation.  The method
also tries to parse anything in the username
following a "." into an integer.  This
requirement is too strict.

Modification:

Remove that requirement.
We also eliminate searching for the pid
on the user URN given to the TPC
client and generate instead a
random 5-digit integer, since
this login 'pid' value is used
only for monitoring purposes.

Result:

Usernames like 'foo.1234:56' are
no longer rejected.

Target: master
Request: 4.0
Request: 3.5
Request: 3.4
Acked-by: Dmitry
Bug: https://rt.dcache.org/Ticket/Display.html?id=9955