### PR TITLE
xrootd4j: loosen yet again username validation

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/OpaqueStringParser.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/OpaqueStringParser.java
@@ -24,8 +24,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.dcache.xrootd.core.XrootdException;
-
 /**
  * According to the xrootd specification, an opaque string has the following
  * format
@@ -90,11 +88,7 @@ public class OpaqueStringParser {
         if (opaque == null || opaque.isEmpty()) {
             return Collections.emptyMap();
         } else {
-            try {
-                opaque = UserNameUtils.checkAllUsernamesValid(opaque);
-            } catch (XrootdException e) {
-                throw new ParseException(e.getMessage());
-            }
+            opaque = UserNameUtils.checkAllUsernamesValid(opaque);
 
             Map<String,String> map = new HashMap<>();
 

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/UserNameUtils.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/UserNameUtils.java
@@ -1,3 +1,4 @@
+
 /**
  * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
  *
@@ -23,8 +24,6 @@ import java.util.regex.Pattern;
 
 import org.dcache.xrootd.core.XrootdException;
 
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ArgInvalid;
-
 /**
  *  It is possible to confuse the OpaqueStringParser by introducing
  *  Posix Non-Compliant UserNames.  This utility guards against
@@ -32,8 +31,9 @@ import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ArgInvalid;
  */
 public class UserNameUtils
 {
+    public static final String XROOTD_MAGIC_NAME = "_anon_";
+
     private static final String XROOTD_UNKNOWN_NAME = "????";
-    private static final String XROOTD_MAGIC_NAME = "_anon_";
     private static final Pattern POSIX_COMPLIANT_UNAME
                     = Pattern.compile("^[a-z_][a-z0-9_-]*[$]?$",
                                       Pattern.CASE_INSENSITIVE);
@@ -50,7 +50,6 @@ public class UserNameUtils
      * @throws XrootdException if the name is invalid.
      */
     public static String checkUsernameValid(String username)
-                    throws XrootdException
     {
         if (XROOTD_UNKNOWN_NAME.equals(username)) {
             return XROOTD_MAGIC_NAME;
@@ -59,7 +58,7 @@ public class UserNameUtils
         if (username == null
                         || (!username.isEmpty()
                         && !POSIX_COMPLIANT_UNAME.matcher(username).matches())) {
-            throw new XrootdException(kXR_ArgInvalid, "Bad user name.");
+            return XROOTD_MAGIC_NAME;
         }
 
         return username;
@@ -77,7 +76,6 @@ public class UserNameUtils
      * @throws XrootdException if any name found in the string is invalid.
      */
     public static String checkAllUsernamesValid(String string)
-                    throws XrootdException
     {
         StringBuilder builder = new StringBuilder();
         int from = 0;
@@ -91,18 +89,20 @@ public class UserNameUtils
             to = string.indexOf(group, from);
             builder.append(string.substring(from, to));
             String[] unamepid = group.split("[.]");
-            if (unamepid.length > 2) {
-                throw new XrootdException(kXR_ArgInvalid, "Bad user name.");
-            }
+
             /*
-             *  POSIX-validate only the part of the name up to a period.
+             *  POSIX-validate only the parts of the name up to the last period.
              */
-            from = to + unamepid[0].length();
-            String valid = checkUsernameValid(unamepid[0]);
-            builder.append(valid);
-            if (unamepid.length == 2) {
-                builder.append(".").append(unamepid[1]);
-                from = from + unamepid[1].length() + 1;
+            if (unamepid.length == 1) {
+                from = to + unamepid[0].length();
+                builder.append(checkUsernameValid(unamepid[0]));
+            } else {
+                for (int i = 0; i < unamepid.length - 1; ++i) {
+                    from = to + unamepid[i].length();
+                    builder.append(checkUsernameValid(unamepid[i])).append(".");
+                }
+                builder.append(unamepid[unamepid.length-1]);
+                from = from + unamepid[unamepid.length-1].length() + 1;
             }
         }
 

--- a/xrootd4j/src/test/java/org/dcache/xrootd/util/UserNameUtilsTest.java
+++ b/xrootd4j/src/test/java/org/dcache/xrootd/util/UserNameUtilsTest.java
@@ -24,8 +24,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import org.dcache.xrootd.core.XrootdException;
-
 import static org.dcache.xrootd.util.OpaqueStringParser.OPAQUE_STRING_PREFIX;
 import static org.junit.Assert.assertEquals;
 
@@ -53,8 +51,8 @@ public class UserNameUtilsTest
 
     private static final String NON_COMPLIANT_CLIENT = "i&v4.29931@foobar.org";
     private static final String NON_COMPLIANT_SRC = "alrossi7&@foobar.org";
-    private static final String NON_COMPLIANT_PID_2 = "foo.bar.29931@foobar.org";
-    private static final String EXTENDED_PID        = "foo.29042:10@foobar.org";
+    private static final String COMPLIANT_PID_2   = "foo.bar.29931@foobar.org";
+    private static final String EXTENDED_PID      = "foo.29042:10@foobar.org";
 
     private static final String COMPLIANT_TPC_SRC = "arossi2020@foobar.org";
     private static final String COMPLIANT_TPC_DLG = "arossi2020@foobar.org";
@@ -83,10 +81,12 @@ public class UserNameUtilsTest
                    UserNameUtils.checkUsernameValid(""));
     }
 
-    @Test( expected=XrootdException.class)
+    @Test
     public void shouldNotAcceptNullUserName() throws Exception
     {
-        UserNameUtils.checkUsernameValid(null);
+        assertEquals("Should have replaced user name",
+                     UserNameUtils.XROOTD_MAGIC_NAME,
+                        UserNameUtils.checkUsernameValid(null));
     }
 
     @Test
@@ -106,26 +106,38 @@ public class UserNameUtilsTest
     }
 
     @Test
+    public void shouldReplaceNonCompliantUserNameWithPeriod() throws Exception
+    {
+        assertEquals("Should have replaced user name.",
+                     UserNameUtils.XROOTD_MAGIC_NAME,
+                     UserNameUtils.checkUsernameValid("a_l_rossi1955-06-01.c"));
+    }
+
+    @Test
     public void shouldNotFailIfClientContainsExtendedPid() throws Exception
     {
         givenOpaqueStringWithClientName(EXTENDED_PID);
         whenStringIsParsed();
     }
 
-    @Test( expected=XrootdException.class)
-    public void shouldNotAcceptUserNameThatBeginsWithNumber() throws Exception
+    @Test
+    public void shouldReplaceUserNameThatBeginsWithNumber() throws Exception
     {
-        UserNameUtils.checkUsernameValid("7a_l_rossi1955-06-01");
+        assertEquals("Should have replaced user name.",
+                     UserNameUtils.XROOTD_MAGIC_NAME,
+                     UserNameUtils.checkUsernameValid("7a_l_rossi1955-06-01"));
     }
 
-    @Test( expected=XrootdException.class)
-    public void shouldNotAcceptUserNameThatContainsUpperCaseLetter() throws Exception
+    @Test
+    public void shouldReplaceUserNameThatContainsUpperCaseLetter() throws Exception
     {
-        UserNameUtils.checkUsernameValid("a_l_Rossi?1955-06-01");
+        assertEquals("Should have replaced user name.",
+                     UserNameUtils.XROOTD_MAGIC_NAME,
+                     UserNameUtils.checkUsernameValid("a_l_Rossi?1955-06-01"));
     }
 
-    @Test( expected=XrootdException.class)
-    public void shouldNotAcceptUserNameThatContainsSpecialCharacters() throws Exception
+    @Test
+    public void shouldReplaceUserNameThatContainsSpecialCharacters() throws Exception
     {
         UserNameUtils.checkUsernameValid("7a_l_rossi?1955-06-01");
     }
@@ -146,24 +158,23 @@ public class UserNameUtilsTest
         assertThatCompliantNamesAreUnchanged();
     }
 
-    @Test( expected=ParseException.class)
-    public void shouldFailIfClientContainsNonCompliantUsername() throws Exception
+    @Test
+    public void shouldNotFailIfClientContainsNonCompliantUsername() throws Exception
     {
         givenOpaqueStringWithClientName(NON_COMPLIANT_CLIENT);
         whenStringIsParsed();
     }
 
-    @Test( expected=ParseException.class)
-    public void shouldFailIfSrcContainsNonCompliantUsername() throws Exception
+    @Test
+    public void shouldNotFailIfSrcContainsNonCompliantUsername() throws Exception
     {
         givenOpaqueStringWithSrcName(NON_COMPLIANT_SRC);
         whenStringIsParsed();
     }
 
-    @Test( expected=ParseException.class)
-    public void shouldFailIfClientContainsDoublePeriod() throws Exception
+    public void shouldNotFailIfClientContainsDoublePeriod() throws Exception
     {
-        givenOpaqueStringWithClientName(NON_COMPLIANT_PID_2);
+        givenOpaqueStringWithClientName(COMPLIANT_PID_2);
         whenStringIsParsed();
     }
 


### PR DESCRIPTION
Motiviation:

https://rb.dcache.org/r/12378/
master@83e87edbe1956760b16f266f9e0c625d75eff07c

was insufficient. There are usernames
for some experiments with '.' and also that begin
with [0-9].

Modfication:

Since the username at login is basically
arbitrary, I have changed the logic not
to throw exceptions.

POSIX compliance is still enforced, but
we allow multiple "." in the opaque
string parsing, accepting everything
up to the last "." as the username
and the last segment as pid:fd.
Anything that is non-compliant
is replace by the MAGIC NAME.

Junit tests adjusted.

Result:

Hopefully everybody is happy.

Target: master
Request: 4.0
Request: 3.5
Request: 3.4
Patch: https://rb.dcache.org/r/12390/
Acked-by: Dmitry