### PR TITLE
xrootd4j: adjust how the 'expect' flag is handled to latest specifica…

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/XrootdProtocol.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/XrootdProtocol.java
@@ -306,6 +306,7 @@ public interface XrootdProtocol {
     byte    kXR_ExpNone                 = 0x00;  // No expectations
     byte    kXR_ExpBind                 = 0x01;  // expect a kXR_bine request
     byte    kXR_ExpGPF                  = 0x02;  // expect a kXR_gpfile request
+    byte    kXR_ExpGPFA                 = 0x20;  // expect an anonymous kXR_gpfile request
     byte    kXR_ExpLogin                = 0x03;  // expect a kXR_login request
     byte    kXR_ExpTPC                  = 0x04;  // expect a third-party copy
 
@@ -323,6 +324,7 @@ public interface XrootdProtocol {
     int     kXR_tlsAny                  = 0x1f000000; // to isolate tls requirement flags
     int     kXR_tlsData                 = 0x01000000; // All data requires a TLS connection
     int     kXR_tlsGPF                  = 0x02000000; // kXR_gpfile requires TLS
+    int     kXR_tlsGPFA                 = 0x20000000; // anonymous kXR_gpfile requires TLS
     int     kXR_tlsLogin                = 0x04000000; // kXR_login requires a TLS connection
     int     kXR_tlsSess                 = 0x08000000; // Connection transition to TLS after login
     int     kXR_tlsTPC                  = 0x10000000; // TPC requests require a TLS connection

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/ServerProtocolFlags.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/ServerProtocolFlags.java
@@ -174,7 +174,14 @@ public class ServerProtocolFlags
     public boolean requiresTLSForGPF()
     {
         boolean response = (flags & kXR_tlsGPF) == kXR_tlsGPF;
-        LOGGER.trace("requiresTLSForLogin ? {}.", response);
+        LOGGER.trace("requiresTLSForGPF ? {}.", response);
+        return response;
+    }
+
+    public boolean requiresTLSForGPFA()
+    {
+        boolean response = (flags & kXR_tlsGPFA) == kXR_tlsGPFA;
+        LOGGER.trace("requiresTLSForGPFA ? {}.", response);
         return response;
     }
 
@@ -295,6 +302,16 @@ public class ServerProtocolFlags
         }
     }
 
+    public void setRequiresTLSForGPFA(boolean value)
+    {
+        LOGGER.trace("setRequiresTLSForGPFA {}.", value);
+        if (value) {
+            flags |= kXR_tlsGPFA;
+        } else {
+            flags &= (~kXR_tlsGPFA);
+        }
+    }
+
     public void setRequiresTLSForLogin(boolean value)
     {
         LOGGER.trace("setRequiresTLSForLogin {}.", value);
@@ -317,7 +334,7 @@ public class ServerProtocolFlags
 
     public void setRequiresTLSForTPC(boolean value)
     {
-        LOGGER.trace("setRequiresTLSForSession {}.", value);
+        LOGGER.trace("setRequiresTLSForTPC {}.", value);
         if (value) {
             flags |= kXR_tlsTPC;
         } else {


### PR DESCRIPTION
…tions

Motivation:

Ongoing modifications to the TLS protocol in xrootd
have slightly adjusted the meaning of the 'expect'
flag sent by the client.

Modification:

Make the necessary adjustments.

Result:

dCache behaves correctly according to protocol
specification.

Target: master
Request: 4.0
Acked-by: Tigran
Patch: https://rb.dcache.org/r/12388/