### PR TITLE
xroot4j-gsi: throw FileNotFoundException if /etc/grid-security/certif…

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/CertChainValidatorProvider.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/CertChainValidatorProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -28,6 +28,8 @@ import eu.emi.security.authn.x509.X509CertChainValidator;
 import eu.emi.security.authn.x509.impl.OpensslCertChainValidator;
 import eu.emi.security.authn.x509.impl.ValidatorParams;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -44,8 +46,16 @@ public class CertChainValidatorProvider
     private final long                   trustAnchorRefreshInterval;
 
     public CertChainValidatorProvider(Properties properties)
+                    throws FileNotFoundException
     {
         caCertificatePath = properties.getProperty("xrootd.gsi.ca.path");
+        if (!new File(caCertificatePath).isDirectory()) {
+            throw new FileNotFoundException(caCertificatePath +
+                                            " is missing: GSI requires the X509 "
+                                                            + "certificate "
+                                                            + "authority CRLs");
+        }
+
         trustAnchorRefreshInterval =
                         TimeUnit.valueOf(properties.getProperty("xrootd.gsi.ca.refresh.unit"))
                                 .toMillis(Integer.parseInt(properties.getProperty("xrootd.gsi.ca.refresh")));

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIAuthenticationFactory.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIAuthenticationFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -18,6 +18,7 @@
  */
 package org.dcache.xrootd.plugins.authn.gsi;
 
+import java.io.FileNotFoundException;
 import java.util.Properties;
 
 import org.dcache.xrootd.plugins.AuthenticationFactory;
@@ -34,6 +35,7 @@ public class GSIAuthenticationFactory implements AuthenticationFactory
     private final CredentialLoader credentialLoader;
 
     public GSIAuthenticationFactory(Properties properties)
+                    throws FileNotFoundException
     {
         this.properties = properties;
         validatorProvider = new CertChainValidatorProvider(properties);

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIAuthenticationProvider.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -18,6 +18,7 @@
  */
 package org.dcache.xrootd.plugins.authn.gsi;
 
+import java.io.FileNotFoundException;
 import java.util.Properties;
 
 import org.dcache.xrootd.plugins.AuthenticationProvider;
@@ -27,6 +28,7 @@ public class GSIAuthenticationProvider implements AuthenticationProvider
 {
     @Override
     public AuthenticationFactory createFactory(String plugin, Properties properties)
+                    throws FileNotFoundException
     {
         return GSIRequestHandler.PROTOCOL.equals(plugin) ?
                         new GSIAuthenticationFactory(properties) : null;

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationFactory.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -20,6 +20,7 @@ package org.dcache.xrootd.plugins.authn.gsi;
 
 import io.netty.channel.ChannelHandler;
 
+import java.io.FileNotFoundException;
 import java.util.Properties;
 
 import org.dcache.xrootd.plugins.ChannelHandlerFactory;
@@ -35,6 +36,7 @@ public class GSIClientAuthenticationFactory implements ChannelHandlerFactory
     private final CredentialLoader credentialLoader;
 
     public GSIClientAuthenticationFactory(Properties properties)
+                    throws FileNotFoundException
     {
         this.properties = properties;
         validatorProvider = new CertChainValidatorProvider(properties);

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationProvider.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -18,6 +18,7 @@
  */
 package org.dcache.xrootd.plugins.authn.gsi;
 
+import java.io.FileNotFoundException;
 import java.util.Properties;
 
 import org.dcache.xrootd.plugins.ChannelHandlerFactory;
@@ -28,6 +29,7 @@ public class GSIClientAuthenticationProvider implements
 {
     @Override
     public ChannelHandlerFactory createFactory(String plugin, Properties properties)
+                    throws FileNotFoundException
     {
         return GSIRequestHandler.PROTOCOL.equals(plugin) ?
                         new GSIClientAuthenticationFactory(properties) : null;


### PR DESCRIPTION
…icatesis missing

Motivation:

See https://github.com/dCache/dcache/issues/5605

Modification:

Report a clearer error message if the cacerts dir
is not defined.

Since master@e0dbedb666 (https://rb.dcache.org/r/12605/)
GSI for TPC is default for the pools, so we
continue to assume that a proper grid context
exists on the pools; those who do not use
it should modify

pool.mover.xrootd.tpc-authn-plugins=gsi,unix

to

pool.mover.xrootd.tpc-authn-plugins=unix

Result:

Reason for startup failure on pool is
intelligible.

Target: master
Request: 4.0
Request: 3.5
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12656/
Closes: #5065
Acked-by: Lea
Acked-by: Tigran