### PR TITLE
xroot4j: on GSI auth error, add info about delegated proxy

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -31,6 +31,7 @@ import org.dcache.xrootd.tpc.AbstractClientAuthnHandler;
 import org.dcache.xrootd.tpc.XrootdTpcClient;
 import org.dcache.xrootd.tpc.XrootdTpcInfo;
 import org.dcache.xrootd.tpc.protocol.messages.InboundAuthenticationResponse;
+import org.dcache.xrootd.tpc.protocol.messages.InboundErrorResponse;
 import org.dcache.xrootd.tpc.protocol.messages.OutboundAuthenticationRequest;
 
 import static io.netty.channel.ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE;
@@ -62,6 +63,24 @@ public class GSIClientAuthenticationHandler extends AbstractClientAuthnHandler
     public void setClient(XrootdTpcClient client)
     {
         super.setClient(client);
+    }
+
+    protected void doOnErrorResponse(ChannelHandlerContext ctx,
+                                     InboundErrorResponse response)
+                    throws XrootdException
+    {
+        if (requestHandler != null) {
+            requestHandler.handleAuthenticationError(response);
+        } else {
+            XrootdException throwable
+                            = new XrootdException(response.getError(),
+                                                  response.getErrorMessage());
+            exceptionCaught(ctx,
+                            new RuntimeException("An authentication error was  "
+                                            + "intercepted before an authentication "
+                                            + "request was sent; "
+                                            + "this is a bug.", throwable));
+        }
     }
 
     protected void doOnAuthenticationResponse(ChannelHandlerContext ctx,

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -43,6 +43,7 @@ import org.dcache.xrootd.security.XrootdSecurityProtocol.BucketType;
 import org.dcache.xrootd.tpc.TpcSigverRequestEncoder;
 import org.dcache.xrootd.tpc.XrootdTpcClient;
 import org.dcache.xrootd.tpc.protocol.messages.InboundAuthenticationResponse;
+import org.dcache.xrootd.tpc.protocol.messages.InboundErrorResponse;
 import org.dcache.xrootd.tpc.protocol.messages.OutboundAuthenticationRequest;
 
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_DecryptErr;
@@ -330,6 +331,9 @@ public abstract class GSIClientRequestHandler extends GSIRequestHandler
     protected abstract X509Credential getClientCredential();
 
     protected abstract Optional<Integer> getClientOpts();
+
+    protected abstract void handleAuthenticationError(InboundErrorResponse response)
+                    throws XrootdException;
 
     protected abstract void loadClientCredential() throws XrootdException;
 

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/post49/GSIPost49ClientRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/post49/GSIPost49ClientRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -36,6 +36,7 @@ import org.dcache.xrootd.plugins.authn.gsi.SerializableX509Credential;
 import org.dcache.xrootd.security.XrootdBucket;
 import org.dcache.xrootd.tpc.XrootdTpcClient;
 import org.dcache.xrootd.tpc.protocol.messages.InboundAuthenticationResponse;
+import org.dcache.xrootd.tpc.protocol.messages.InboundErrorResponse;
 import org.dcache.xrootd.tpc.protocol.messages.OutboundAuthenticationRequest;
 
 import static org.dcache.xrootd.security.XrootdSecurityProtocol.BucketType.kXRS_cipher;
@@ -74,6 +75,15 @@ public class GSIPost49ClientRequestHandler extends GSIClientRequestHandler
     public int getProtocolVersion()
     {
         return PROTO_WITH_DELEGATION;
+    }
+
+    @Override
+    protected void handleAuthenticationError(InboundErrorResponse response)
+                    throws XrootdException {
+        String message = response.getErrorMessage() + " –– user proxy was "
+                            + client.getInfo().getDelegatedProxy() == null
+                            ? "not " : "" + "delegated.";
+        throw new XrootdException(response.getError(), message);
     }
 
     public OutboundAuthenticationRequest handleCertStep(InboundAuthenticationResponse response,

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/pre49/GSIPre49ClientRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/pre49/GSIPre49ClientRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -28,6 +28,7 @@ import org.dcache.xrootd.plugins.authn.gsi.GSIClientRequestHandler;
 import org.dcache.xrootd.plugins.authn.gsi.GSICredentialManager;
 import org.dcache.xrootd.tpc.XrootdTpcClient;
 import org.dcache.xrootd.tpc.protocol.messages.InboundAuthenticationResponse;
+import org.dcache.xrootd.tpc.protocol.messages.InboundErrorResponse;
 import org.dcache.xrootd.tpc.protocol.messages.OutboundAuthenticationRequest;
 
 import static org.dcache.xrootd.security.XrootdSecurityProtocol.BucketType.kXRS_puk;
@@ -79,6 +80,13 @@ public class GSIPre49ClientRequestHandler extends GSIClientRequestHandler
     @Override
     protected String getSyncCipherMode() {
         return SYNC_CIPHER_MODE_PADDED;
+    }
+
+    @Override
+    protected void handleAuthenticationError(InboundErrorResponse response)
+                    throws XrootdException {
+        throw new XrootdException(response.getError(),
+                                  response.getErrorMessage());
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Problems like those encountered in RT Ticket https://rt.dcache.org/Ticket/Display.html?id=10057
have to do with the refusal of the xrdcp client to delegate a proxy because the hostname
has not been verified or has been verified using DNS lookup.   These can usually
be solved by having the host certs reissued with a SAN extension for the alias.

However, the user may be in the dark as to why an authentication error occurs.  This
can be from either the total absence of a proxy on the dcache destination side (pool)
or because the TPC client has fallen back to generating the proxy from the host cert
whose DN is not mapped on the source server.

Modification:

On an error response during the authentication phase, if the protocol is gsi,
report whether or not the pool received a delegated proxy.  This should help
in the diagnosis.

Result:

A little less mystery as to what might have gone wrong.

Target: master
Request: 4.0
Request: 3.5
Acked-by: Paul