### PR TITLE
xroot4j: swap scgi authz for authz on TPC

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -444,12 +444,25 @@ public class XrootdTpcClient
         StringBuilder fullPath = new StringBuilder();
 
         /*
+         *  If the source token exists, put it first.
+         */
+        String sourceToken = info.getSourceToken();
+        if (sourceToken != null) {
+            fullPath.append(XrootdTpcInfo.AUTHZ)
+                    .append(OpaqueStringParser.OPAQUE_SEPARATOR)
+                    .append(sourceToken);
+        }
+
+        /*
          *  If delegation is not being used, forward the rendezvous key and
          *  client info.
          */
         String protocol = (String)authnContext.get("protocol");
         String tpcDlg = (String)authnContext.get("tpcdlg");
         if ("gsi".equals(protocol) && !"gsi".equalsIgnoreCase(tpcDlg)) {
+            if (fullPath.length() > 0) {
+                fullPath.append(OpaqueStringParser.OPAQUE_PREFIX);
+            }
             fullPath.append(XrootdTpcInfo.CLIENT)
                     .append(OpaqueStringParser.OPAQUE_SEPARATOR)
                     .append(userUrn)

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -53,6 +53,8 @@ public class XrootdTpcInfo {
 
     public static final String DLG = "tpc.dlg";
 
+    public static final String DLGON = "tpc.dlgon";
+
     public static final String DST = "tpc.dst";
 
     public static final String LOGICAL_NAME = "tpc.lfn";
@@ -76,6 +78,21 @@ public class XrootdTpcInfo {
     public static final String SPR = "tpc.spr";
 
     /**
+     *  This is the scgi added for delegation purposes.
+     *  <p/>
+     *  From the SLAC documentation:
+     *  <p/>
+     *  The CGI information from the source URL. This element needs to be
+     *  specified only if a) delegation is being used and b) meaningful
+     *  CGI is present on the source URL (see the notes on the definition
+     *  of meaningful). Since a CGI string may not be the value of a
+     *  CGI element, all ampersands in scgi should be converted to tab
+     *  characters. The destination server is responsible for converting
+     *  the tabs to ampersands before initiating the copy.
+     */
+    public static final String SCGI = "tpc.scgi";
+
+    /**
      * <p>Opaque string name-value constant values.</p>
      */
     public static final String PLACEMENT = "placement";
@@ -87,6 +104,8 @@ public class XrootdTpcInfo {
     public static final String CRC32 = "crc32";
 
     public static final String MD5 = "md5";
+
+    public static final String AUTHZ= "authz";
 
     private static final Set<String> TPC_KEYS
                     = ImmutableSet.of(STAGE,
@@ -100,8 +119,11 @@ public class XrootdTpcInfo {
                                       SIZE_IN_BYTES,
                                       STR,
                                       DLG,
+                                      DLGON,
                                       TPR,
-                                      SPR);
+                                      SPR,
+                                      SCGI,
+                                      AUTHZ);
 
     public enum Status
     {
@@ -191,6 +213,11 @@ public class XrootdTpcInfo {
     private String loginToken;
 
     /**
+     * <p>Source authorization token.</p>
+     */
+    private String sourceToken;
+
+    /**
      * <p>Delegated proxy object</p>
      */
 
@@ -208,7 +235,7 @@ public class XrootdTpcInfo {
      *    Calling this constructor implies a READY status.</p>
      *    Ttl is not relevant.
      */
-    public XrootdTpcInfo(Map<String, String> opaque)
+    public XrootdTpcInfo(Map<String, String> opaque) throws ParseException
     {
         this(opaque.get(RENDEZVOUS_KEY));
         this.lfn = opaque.get(LOGICAL_NAME);
@@ -220,6 +247,7 @@ public class XrootdTpcInfo {
             this.asize = Long.parseLong(asize);
         }
         status = Status.READY;
+        findSourceToken(opaque);
         addExternal(opaque);
     }
 
@@ -230,8 +258,8 @@ public class XrootdTpcInfo {
      * <p>Will not overwrite existing non-null values.</p>
      */
     public synchronized XrootdTpcInfo addInfoFromOpaque(String slfn,
-                                           Map<String, String> opaque)
-    {
+                                                        Map<String, String> opaque)
+                    throws ParseException {
         if (this.lfn == null) {
             this.lfn = slfn;
         }
@@ -266,6 +294,10 @@ public class XrootdTpcInfo {
 
         if (this.status == null) {
             this.status = Status.PENDING;
+        }
+
+        if (sourceToken == null) {
+            findSourceToken(opaque);
         }
 
         addExternal(opaque);
@@ -315,7 +347,20 @@ public class XrootdTpcInfo {
             if (!opaque.startsWith("?")) {
                 opaque = "?" + opaque;
             }
-            info.addExternal(OpaqueStringParser.getOpaqueMap(opaque));
+
+            Map<String, String> map = OpaqueStringParser.getOpaqueMap(opaque);
+
+            /*
+             *  The opaque data returned with the redirect will usually
+             *  be the same as what the client provided the redirector,
+             *  but it is possible that the redirector may substitute
+             *  a new token to use against the new endpoint.
+             *
+             *  In either case, the token will be the value of 'authz'.
+             */
+            info.sourceToken = map.get(AUTHZ);
+
+            info.addExternal(map);
         }
 
         info.status = Status.READY;
@@ -377,6 +422,8 @@ public class XrootdTpcInfo {
                                   .append(status)
                                   .append(")(token ")
                                   .append(loginToken)
+                                  .append(")(source token ")
+                                  .append(sourceToken)
                                   .append(")(external [")
                                   .append(external)
                                   .append("])")
@@ -407,6 +454,11 @@ public class XrootdTpcInfo {
     public Serializable getDelegatedProxy()
     {
         return delegatedProxy;
+    }
+
+    public String getSourceToken()
+    {
+        return sourceToken;
     }
 
     public String getExternal()
@@ -567,6 +619,18 @@ public class XrootdTpcInfo {
             } else {
                 srcPort = XrootdProtocol.DEFAULT_PORT;
             }
+        }
+    }
+
+    private void findSourceToken(Map<String, String> opaque) throws ParseException
+    {
+        String scgi = opaque.get(SCGI);
+        if (scgi != null) {
+            scgi = scgi.replaceAll("\\t+",
+                                   String.valueOf(OpaqueStringParser.OPAQUE_PREFIX));
+            Map<String, String> sourceOpaque
+                            = OpaqueStringParser.getOpaqueMap(scgi);
+            sourceToken = sourceOpaque.get(AUTHZ);
         }
     }
 }


### PR DESCRIPTION
Motivation:

When doing TPC with authorization tokens, the xrdcp
client prepares the path URL it gives to the destination
server with two tokens, authz=<dest> and tpc.scgi=authz=<src>.
The former is to be used to authorize at the server/door/pool
endpoint, whereas the latter is to used by the TPC client
to authorize against the source.

Currently there is a flaw in the implementation of the TPC
client whereby it uses the authz <dest> token to communicate
with the source.  This problem went undiscovered in
the prototyping of SciToken authorization because the
same configuration was used on both dCache endpoints
(and the vanilla xrootd server implemetation was not yet
available to test).

Modification:

Add the necessary parsing and swap of the query elements
in the XrootdTPCInfo object and include the source token
on the full path constructed by the XrootdTPCClient.

Result:

Authorization where the tokens/requirements on the
source and destination endpoints are distinct now
succeeds.

In addition, this correction should make the ALICE
xrootd plugin work properly as well.

Target: master
Request: 4.0
Patch: https://rb.dcache.org/r/12828/
Acked-by: Tigran
Acked-by: Dmitry
Acked-by: Paul