### PR TITLE
xrootd4j: get source size from stat on open on TPC

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientSourceHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientSourceHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -181,6 +181,7 @@ public abstract class AbstractClientSourceHandler extends
             client.setFhandle(response.getFhandle());
             client.setCpsize(response.getCpsize());
             client.setCptype(response.getCptype());
+            tpcInfo.setFileStatus(response.getFileStatus());
             sendReadRequest(ctx);
         } else {
             String error = String.format("Open of %s on %s failed with status %s.",

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
@@ -26,13 +26,18 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.dcache.xrootd.core.XrootdException;
 import org.dcache.xrootd.protocol.XrootdProtocol;
 import org.dcache.xrootd.tpc.protocol.messages.InboundRedirectResponse;
+import org.dcache.xrootd.util.FileStatus;
 import org.dcache.xrootd.util.OpaqueStringParser;
 import org.dcache.xrootd.util.ParseException;
+
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ArgMissing;
 
 /**
  * <p>Metadata established via interaction between user client, source and
@@ -183,7 +188,7 @@ public class XrootdTpcInfo {
     /**
      * <p>Source size.</p>
      */
-    private long asize;
+    private Long asize;
 
     /**
      * <p>Status of the transfer request.</p>
@@ -218,6 +223,11 @@ public class XrootdTpcInfo {
     private String sourceToken;
 
     /**
+     * <p>The stat info received on the TPC open call.</p>
+     */
+    private FileStatus fileStatus;
+
+    /**
      * <p>Delegated proxy object</p>
      */
 
@@ -229,6 +239,11 @@ public class XrootdTpcInfo {
         this.key = key;
         this.createdTime = System.currentTimeMillis();
     }
+
+    /*
+     *  Computed.
+     */
+    private OptionalLong fileSize = OptionalLong.empty();
 
     /**
      * <p>Initializes everything from the map instance.
@@ -303,6 +318,23 @@ public class XrootdTpcInfo {
         addExternal(opaque);
 
         return this;
+    }
+
+    public long computeFileSize() throws XrootdException
+    {
+        if (!fileSize.isPresent()) {
+            if (fileStatus == null) {
+                if (asize == null) {
+                    throw new XrootdException(kXR_ArgMissing,
+                                              "Cannot read source; file size is unknown.");
+                }
+                fileSize = OptionalLong.of(asize); // asize not null here
+            } else {
+                fileSize = OptionalLong.of(fileStatus.getSize());
+            }
+        }
+
+        return fileSize.getAsLong();
     }
 
     /**
@@ -436,11 +468,6 @@ public class XrootdTpcInfo {
                         > (startTime + TimeUnit.SECONDS.toMillis(ttl));
     }
 
-    public long getAsize()
-    {
-        return asize;
-    }
-
     public String getCks()
     {
         return cks;
@@ -540,6 +567,11 @@ public class XrootdTpcInfo {
     public void setDst(String dst)
     {
         this.dst = dst;
+    }
+
+    public void setFileStatus(FileStatus fileStatus)
+    {
+        this.fileStatus = fileStatus;
     }
 
     public void setFd(int fd)

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundOpenReadOnlyResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundOpenReadOnlyResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -22,6 +22,8 @@ import io.netty.buffer.ByteBuf;
 
 import java.nio.charset.StandardCharsets;
 
+import org.dcache.xrootd.util.FileStatus;
+
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_open;
 
 /**
@@ -29,11 +31,11 @@ import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_open;
  */
 public class InboundOpenReadOnlyResponse extends AbstractXrootdInboundResponse
 {
-    private final int    resplen;
-    private final int    fhandle;
+    private final        int    resplen;
+    private final        int    fhandle;
     private final int    cpsize;  // should be 0, since we request kXR_restat
     private final int    cptype;  // should have first byte = \0, no compression
-    private final String info;
+    private final FileStatus fileStatus;
 
     public InboundOpenReadOnlyResponse(ByteBuf buffer)
     {
@@ -43,10 +45,12 @@ public class InboundOpenReadOnlyResponse extends AbstractXrootdInboundResponse
         cpsize = buffer.getInt(12);
         cptype = buffer.getInt(16);
         int len = resplen - 12;
-        if (len > 0) {
-            info = buffer.toString(20, len, StandardCharsets.US_ASCII);
+        if (resplen > 0) {
+            fileStatus = new FileStatus(buffer.toString(20,
+                                                        len,
+                                                        StandardCharsets.US_ASCII));
         } else {
-            info = null;
+            fileStatus = null;
         }
     }
 
@@ -62,8 +66,8 @@ public class InboundOpenReadOnlyResponse extends AbstractXrootdInboundResponse
         return fhandle;
     }
 
-    public String getInfo() {
-        return info;
+    public FileStatus getFileStatus() {
+        return fileStatus;
     }
 
     @Override

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/FileStatus.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/FileStatus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -40,6 +40,18 @@ public class FileStatus
         this.size = size;
         this.flags = flags;
         this.modtime = modtime;
+    }
+
+    /*
+     * Id, size, flags, mtime
+     */
+    public FileStatus(String info)
+    {
+        String[] parts = info.trim().split("[\\s]");
+        this.id = Long.parseLong(parts[0]);
+        this.size = Long.parseLong(parts[1]);
+        this.flags = Integer.parseInt(parts[2]);
+        this.modtime = Long.parseLong(parts[3]);
     }
 
     public long getSize() {


### PR DESCRIPTION
Motivation:

In the original xroot TPC protocol, the client
opens the source file before handing off the
TPC request to the destination.  As a result,
the size of the file as discovered by the
client becomes a part of the opaque data
(as the 'oss.asize' CGI element).

When delegation was introduced, and with it
the so-called "TPC lite" protocol, the
open became facultative.  It so happens
that the later versions of the client
still do this, but it is no longer required.

When testing TLS, I happened to uncover
what SLAC has now acknowledged to be a bug:
using 'xroots' rather than 'xroot' as the
URL protocol for the source makes the
client skip opening the file.  While
they have corrected this bug, the
absence of the 'oss.asize' (it was 0),
which led to the TPC client delivering
only one block of the file (4MB) because
it had no expected file size to work with,
drove home the point that the TPC client
should not rely on the opaque data for
size, but should take it from the
stat info returned from the source on
open.

Modification:

Parse the returned info bytes into
FileStatus on the open response.
Access this info for the file size.
Use this to override oss.asize if
present, or in place of it if
absent.  Change oss.asize in
the TPC info to Long so that
a null check can be performed.

Result:

Correct behavior (complete file read)
even if oss.asize is not set.

Target:  master
Request: 4.0
Request: 3.5
Patch: https://rb.dcache.org/r/12907
Acked-by: Dmitry