### PR TITLE
xrootd4j: fix how we turn off signing policy if TLS is on

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientRequestHandler.java
@@ -200,7 +200,7 @@ public abstract class GSIClientRequestHandler extends GSIRequestHandler
                                      + "signing is on? {}; tls ? {}.",
                      signingPolicy.isSigningOn(), tlsSessionInfo.getClientTls());
         TpcSigverRequestEncoder sigverRequestEncoder = null;
-        if (!tlsSessionInfo.clientUsesTls() && signingPolicy.isSigningOn()) {
+        if (signingPolicy.isSigningOn()) {
             sigverRequestEncoder = new TpcSigverRequestEncoder(bufferHandler,
                                                                signingPolicy);
         }

--- a/xrootd4j-unix/src/main/java/org/dcache/xrootd/plugins/authn/unix/UnixClientAuthenticationHandler.java
+++ b/xrootd4j-unix/src/main/java/org/dcache/xrootd/plugins/authn/unix/UnixClientAuthenticationHandler.java
@@ -101,8 +101,7 @@ public class UnixClientAuthenticationHandler extends AbstractClientAuthnHandler
         LOGGER.debug("Getting (optional) signed hash verification encoder, "
                                      + "signing is on? {}; tls ? {}.",
                      signingPolicy.isSigningOn(), tlsSessionInfo.getClientTls());
-
-        if (!tlsSessionInfo.clientUsesTls() && signingPolicy.isSigningOn()) {
+        if (signingPolicy.isSigningOn()) {
             /*
              * Insert sigver encoder into pipeline.  Added after the encoder,
              * but for outbound processing, it gets called before the encoder.

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdProtocolRequestHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdProtocolRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -70,6 +70,11 @@ public class XrootdProtocolRequestHandler extends XrootdRequestHandler
                                              msg.getExpect());
 
         if (tlsSessionInfo.serverUsesTls()) {
+            /*
+             *  If there is/will be TLS, turn off signing by overriding
+             *  local settings.
+             */
+            signingPolicy = SigningPolicy.OFF;
             boolean isStarted = tlsSessionInfo.serverTransitionedToTLS(kXR_protocol,
                                                                         ctx);
             LOGGER.debug("kXR_protocol, server has now transitioned to tls? {}.",

--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/SigningPolicy.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/SigningPolicy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -38,6 +38,8 @@ import static org.dcache.xrootd.security.XrootdSecurityProtocol.*;
  */
 public class SigningPolicy
 {
+    public static final SigningPolicy OFF = new SigningPolicy();
+
     private final int                   secLvl;
     private final Map<Integer, Integer> overrides;
     private final byte                  secOFrce;


### PR DESCRIPTION
Motivation:

Signed hash verification is unnecessary if TLS is on,
whether before or after authentication.

Hence, we should not tell the client to turn it on
if going to TLS is being or will be recommended.

For the TPC client, life is simpler.  We simply
rely on the source to tell us whether to verify
signed hashes or not.

Modification:

To be consistent, we must do this immediately
in the protocol response.  If the server "uses"
TLS ... which indicates either an instruction
to go to tls before login or after, the sigver
settings are overridden with a default object
which turns them off.

Result:

The server will not erroneously require the
client to send the signed hashes.

Our TPC client simply obeys the source
end directive.

Target: master
Request: 4.0
Request: 3.5
Patch: https://rb.dcache.org/r/12915/
Acked-by: Tigran