### PR TITLE
xrootd4j: use CGI tpc.dlgon to determine if delegation is on

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/post49/GSIPost49ClientRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/post49/GSIPost49ClientRequestHandler.java
@@ -64,11 +64,6 @@ public class GSIPost49ClientRequestHandler extends GSIClientRequestHandler
                                          XrootdTpcClient client)
     {
         super(credentialManager, client);
-        /*
-         *  Request handler was chosen because endpoint supports delegation.
-         *  Let the client know this.
-         */
-        client.getAuthnContext().put("tpcdlg", "gsi");
     }
 
     @Override

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/pre49/GSIPre49ClientRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/pre49/GSIPre49ClientRequestHandler.java
@@ -39,12 +39,6 @@ public class GSIPre49ClientRequestHandler extends GSIClientRequestHandler
                                         XrootdTpcClient client)
     {
         super(credentialManager, client);
-        /*
-         *  Request handler was chosen because endpoint
-         *  does not support delegation.
-         *  Let the client know this.
-         */
-        client.getAuthnContext().put("tpcdlg", "tpcdlg");
     }
 
     @Override

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
@@ -49,6 +49,7 @@ import org.dcache.xrootd.core.XrootdException;
 import org.dcache.xrootd.core.XrootdSessionIdentifier;
 import org.dcache.xrootd.plugins.ChannelHandlerFactory;
 import org.dcache.xrootd.security.SigningPolicy;
+import org.dcache.xrootd.tpc.XrootdTpcInfo.Delegation;
 import org.dcache.xrootd.tpc.core.XrootdClientDecoder;
 import org.dcache.xrootd.tpc.core.XrootdClientEncoder;
 import org.dcache.xrootd.tpc.protocol.messages.InboundAuthenticationResponse;
@@ -457,9 +458,7 @@ public class XrootdTpcClient
          *  If delegation is not being used, forward the rendezvous key and
          *  client info.
          */
-        String protocol = (String)authnContext.get("protocol");
-        String tpcDlg = (String)authnContext.get("tpcdlg");
-        if ("gsi".equals(protocol) && !"gsi".equalsIgnoreCase(tpcDlg)) {
+        if (info.getDlgon() == Delegation.OFF) {
             if (fullPath.length() > 0) {
                 fullPath.append(OpaqueStringParser.OPAQUE_PREFIX);
             }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
@@ -136,6 +136,26 @@ public class XrootdTpcInfo {
     }
 
     /**
+     *  Delegation
+     */
+    enum Delegation
+    {
+        OFF, ON;
+
+        public static Delegation valueOf(Map<String, String> opaque) {
+            String value = opaque.get(DLGON);
+            if (value == null) {
+                return OFF;
+            }
+            switch(opaque.get(DLGON)) {
+                case "1": return ON;
+                default:
+                    return OFF;
+            }
+        }
+    }
+
+    /**
      * <p>Rendez-vous token provided by client.</p>
      */
     private final String key;
@@ -144,6 +164,8 @@ public class XrootdTpcInfo {
      * <p>For eviction management.</p>
      */
     private final long createdTime;
+
+    private Delegation dlgon;
 
     /**
      * <p>The client identifier, in the form [user].[pid]@[hostname]</p>
@@ -253,6 +275,7 @@ public class XrootdTpcInfo {
     public XrootdTpcInfo(Map<String, String> opaque) throws ParseException
     {
         this(opaque.get(RENDEZVOUS_KEY));
+        this.dlgon = Delegation.valueOf(opaque);
         this.lfn = opaque.get(LOGICAL_NAME);
         this.dst = opaque.get(DST);
         setSourceFromOpaque(opaque);
@@ -278,6 +301,8 @@ public class XrootdTpcInfo {
         if (this.lfn == null) {
             this.lfn = slfn;
         }
+
+        this.dlgon = Delegation.valueOf(opaque);
 
         if (this.org == null) {
             this.org = opaque.get(CLIENT);
@@ -358,7 +383,7 @@ public class XrootdTpcInfo {
         }
 
         info.src = info.srcHost + ":" + info.srcPort;
-
+        info.dlgon = dlgon;
         info.lfn = lfn;
         info.asize = asize;
         info.cks = cks;
@@ -432,6 +457,8 @@ public class XrootdTpcInfo {
     {
         return new StringBuilder().append("(key ")
                                   .append(key)
+                                  .append(")(dlgon ")
+                                  .append(dlgon)
                                   .append(")(dst ")
                                   .append(dst)
                                   .append(")(src ")
@@ -481,6 +508,11 @@ public class XrootdTpcInfo {
     public Serializable getDelegatedProxy()
     {
         return delegatedProxy;
+    }
+
+    public Delegation getDlgon()
+    {
+        return dlgon;
     }
 
     public String getSourceToken()


### PR DESCRIPTION
Motivation:

For xrootd TPC there are two protocols, one which uses the
rendez-vous key, and one which relies on delegated credentials.
In the latter case, various tpc CGI elements should not be
sent by the TPC client to the source, or it will get
confused and think the initiating client needs to call
open as well (which it does not when delegating).

Currently, our TPC client filters out those elements
by checking some ad hoc properties the GSI module adds
to the authentication context.

This solution, however, is not standard and would have
to be reimplemented for each new protocol in which
delegation is possible (like Scitokens).

Fortunately, since the original TPC protocol was designed,
a new CGI, "tpc.dlgon", was added with value either 0 (OFF)
or 1 (ON), which allows the destination server to
tell the TPC client what to do.

Modification:

Eliminate the ad hoc solution and add a check of tpc.dlgon.

Result:

Correct behavior not only for GSI but automatically for
any protocols called with "--tpc delegate only" on the
client command line.

Target: master
Request: 4.0
Request: 3.5
Patch: https://rb.dcache.org/r/12935/
Acked-by: Tigran