### PR TITLE
xrootd4j: move TLS (mostly) from dCache to xrootd4j

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/tls/TLSHandlerProvider.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/tls/TLSHandlerProvider.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ *
+ * This file is part of xrootd4j.
+ *
+ * xrootd4j is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * xrootd4j is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with xrootd4j.  If not, see http://www.gnu.org/licenses/.
+ */
+package org.dcache.xrootd.plugins.tls;
+
+import com.google.common.base.Strings;
+
+import java.util.Properties;
+
+import org.dcache.xrootd.plugins.ChannelHandlerFactory;
+import org.dcache.xrootd.plugins.ChannelHandlerProvider;
+
+public class TLSHandlerProvider implements ChannelHandlerProvider
+{
+    public static final String PLUGIN = "ssl-handler";
+    public static final String CLIENT_PLUGIN = "ssl-client-handler";
+
+    private static final String FACTORY_FQN = "xrootd.security.tls.handler-factory.class";
+
+    @Override
+    public ChannelHandlerFactory createFactory(String plugin,
+                                               Properties properties)
+                    throws Exception
+    {
+        Class<?> clzz = getFactoryClass(properties);
+        SSLHandlerFactory factory = null;
+
+        if (plugin.equals(PLUGIN)) {
+            factory = (SSLHandlerFactory)clzz.newInstance();
+            factory.initialize(properties, true);
+        } else if (plugin.equals(CLIENT_PLUGIN)) {
+            factory = (SSLHandlerFactory)clzz.newInstance();
+            factory.initialize(properties, false);
+        }
+
+        return factory;
+    }
+
+    private Class<?> getFactoryClass(Properties properties)
+                    throws ClassNotFoundException, ClassCastException
+    {
+        String handlerImpl = properties.getProperty(FACTORY_FQN);
+
+        if (Strings.emptyToNull(handlerImpl) == null) {
+            throw new ClassNotFoundException("tls handler factory has not "
+                                                             + "been defined.");
+        }
+
+        Class<?> clzz = Thread.currentThread().getContextClassLoader()
+                              .loadClass(handlerImpl);
+
+        if (!SSLHandlerFactory.class.isAssignableFrom(clzz)) {
+            String fatal = "The provided tls handler factory class must extend "
+                            + SSLHandlerFactory.class;
+            throw new ClassCastException(fatal);
+        }
+
+        return clzz;
+    }
+}

--- a/xrootd4j/src/main/resources/META-INF/services/org.dcache.xrootd.plugins.ChannelHandlerProvider
+++ b/xrootd4j/src/main/resources/META-INF/services/org.dcache.xrootd.plugins.ChannelHandlerProvider
@@ -1,2 +1,3 @@
 org.dcache.xrootd.core.XrootdAuthenticationHandlerProvider
 org.dcache.xrootd.core.XrootdAuthorizationHandlerProvider
+org.dcache.xrootd.plugins.tls.TLSHandlerProvider

--- a/xrootd4j/src/main/resources/default.properties
+++ b/xrootd4j/src/main/resources/default.properties
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+#
+# This file is part of xrootd4j.
+#
+# xrootd4j is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# xrootd4j is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with xrootd4j.  If not, see http://www.gnu.org/licenses/.
+#
+
+xrootd.security.tls.handler-factory.class=


### PR DESCRIPTION
Motivation:

Except for a very small implementation-specific method
providing the SLL context, the TLS-Netty functions can
all be moved into the library for general availability.

Modification:

Create an abstract handler, allow the the factory
to instantiate it on the basis of a property
giving the class FQN.

Result:

Only a residual class is left for dCache to implement.

Target: master
Patch: https://rb.dcache.org/r/12916/
Acked-by: Tigran