### PR TITLE
xrootd4j: remove io.netty LogHandler from TPC client pipeline

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
@@ -30,8 +30,6 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.handler.logging.LogLevel;
-import io.netty.handler.logging.LoggingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -709,13 +707,6 @@ public class XrootdTpcClient
                                 List<ChannelHandlerFactory> plugins,
                                 TpcSourceReadHandler readHandler)
     {
-        if (LOGGER.isTraceEnabled()) {
-            pipeline.addLast("logger", new LoggingHandler(XrootdTpcClient.class,
-                                                             LogLevel.TRACE));
-        } else if (LOGGER.isDebugEnabled()) {
-            pipeline.addLast("logger", new LoggingHandler(XrootdTpcClient.class));
-        }
-
         pipeline.addLast("decoder", new XrootdClientDecoder(this));
         pipeline.addLast("encoder", new XrootdClientEncoder(this));
 


### PR DESCRIPTION
Motivation:

It seems that io.netty logging does not play well
at the TRACE level with the turbo filter check of
trace enabled.  This means that the logger gets
added to the pipeline regardless.  The is very
costly in terms of bandwidth as the io.netty
logger does a hex dump of every message received.

Modification:

The TPC client really does not need to enable
io.netty logging under normal conditions,
so we can safely eliminate adding it to
the pipeline.

Result:

Bandwidth for TPC is restored to what is
reasonably expected.

Target: master
Request: 4.1
Request: 4.0
Patch: https://rb.dcache.org/r/13038
Acked-by: Dmitry
Acked-by: Lea