### PR TITLE
xrootd4j: improve handling of TPC read requests

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSourceReadHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSourceReadHandler.java
@@ -94,7 +94,7 @@ public abstract class TpcSourceReadHandler extends AbstractClientSourceHandler
     {
         try {
             XrootdTpcInfo tpcInfo = client.getInfo();
-            long fileSize = 0L;
+            long fileSize;
 
             try {
                 fileSize = tpcInfo.computeFileSize();
@@ -124,6 +124,13 @@ public abstract class TpcSourceReadHandler extends AbstractClientSourceHandler
             }
 
             long writeOffset = client.getWriteOffset();
+            long remaining = fileSize - writeOffset;
+
+            if (bytesRcvd > remaining) {
+                LOGGER.error("client received from the source "
+                                             + "server {} bytes past EOF.",
+                             bytesRcvd-remaining);
+            }
 
             if (bytesRcvd > 0) {
                 try {
@@ -179,7 +186,7 @@ public abstract class TpcSourceReadHandler extends AbstractClientSourceHandler
                              client.getStreamId());
                 handleTransferTerminated(kXR_ok, null, ctx);
             }
-        } finally {
+       } finally {
             ReferenceCountUtil.release(response);
         }
     }
@@ -219,20 +226,34 @@ public abstract class TpcSourceReadHandler extends AbstractClientSourceHandler
     protected void sendReadRequest(ChannelHandlerContext ctx)
     {
         XrootdTpcInfo tpcInfo = client.getInfo();
-        LOGGER.debug("sendReadRequest to {}, channel {}, stream {}, "
-                                     + "fhandle {}, offset {}, chunksize {}.",
-                     tpcInfo.getSrc(),
-                     ctx.channel().id(),
-                     client.getStreamId(),
-                     client.getFhandle(),
-                     client.getWriteOffset(),
-                     getChunkSize());
-        client.setExpectedResponse(kXR_read);
+        int requestBlock;
+        try {
+            long remaining = tpcInfo.computeFileSize() - client.getWriteOffset();
+
+            if (remaining < 0) {
+                throw new XrootdException(kXR_IOError,
+                                          "tpc request has written beyond EOF.");
+            }
+
+            requestBlock = (int)Math.min(getChunkSize(), remaining);
+            LOGGER.debug("sendReadRequest to {}, channel {}, stream {}, "
+                          + "fhandle {}, offset {}, requested block {}.",
+                         tpcInfo.getSrc(),
+                         ctx.channel().id(),
+                         client.getStreamId(),
+                         client.getFhandle(),
+                         client.getWriteOffset(),
+                         requestBlock);
+            client.setExpectedResponse(kXR_read);
+        } catch (XrootdException e) {
+            exceptionCaught(ctx, e);
+            return;
+        }
 
         ctx.writeAndFlush(new OutboundReadRequest(client.getStreamId(),
                                                   client.getFhandle(),
                                                   client.getWriteOffset(),
-                                                  getChunkSize()),
+                                                  requestBlock),
                           ctx.newPromise())
            .addListener(FIRE_EXCEPTION_ON_FAILURE);
         client.startTimer(ctx);


### PR DESCRIPTION
Motivation:

https://github.com/xrootd/xrootd/issues/1454

While testing against the RAL server, we
encountered an issue with buffer size/request block
that is a known bug in the rados striper
(used by the xrootd Ceph plug-in).

The problem (sending back garbage bytes beyond
EOF) results in a corrupt file error.

The xrootd client reportedly prevents
something like this from happening because
it requests only the exact number of bytes
left on the last chunk.

Modification:

Modify the way the final
request is handled by not asking for
the default block size, but only for
the remaining bytes, which conforms
with the way the native xrootd client
behaves.

For bytes > remaining, log an error.  Then,
if we have written past EOF, throw an exception.

Result:

A clearer indication of a failure on
the source server side when too many
bytes are sent, and hopefully a remedy
for avoiding that situation.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.5
Patch: https://rb.dcache.org/r/13124/
Requires-notes: yes
Requires-book: no
Acked-by: Tigran
Acked-by: Paul