### PR TITLE
xrootd4j-unix: revert credential to username

### DIFF
--- a/xrootd4j-unix/src/main/java/org/dcache/xrootd/plugins/authn/unix/UnixClientAuthenticationHandler.java
+++ b/xrootd4j-unix/src/main/java/org/dcache/xrootd/plugins/authn/unix/UnixClientAuthenticationHandler.java
@@ -3,27 +3,29 @@
  *
  * This file is part of xrootd4j.
  *
- * xrootd4j is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * xrootd4j is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
  *
- * xrootd4j is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * xrootd4j is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with xrootd4j.  If not, see http://www.gnu.org/licenses/.
+ * You should have received a copy of the GNU Lesser General Public License along with xrootd4j.  If
+ * not, see http://www.gnu.org/licenses/.
  */
 package org.dcache.xrootd.plugins.authn.unix;
+
+import static io.netty.channel.ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_auth;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_error;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ok;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelId;
-
 import java.util.function.Consumer;
-
 import org.dcache.xrootd.core.XrootdException;
 import org.dcache.xrootd.security.SigningPolicy;
 import org.dcache.xrootd.security.TLSSessionInfo;
@@ -34,12 +36,6 @@ import org.dcache.xrootd.tpc.XrootdTpcInfo;
 import org.dcache.xrootd.tpc.protocol.messages.InboundAuthenticationResponse;
 import org.dcache.xrootd.tpc.protocol.messages.OutboundAuthenticationRequest;
 
-import static io.netty.channel.ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE;
-import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_auth;
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_error;
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ok;
-
 /**
  *  <p>Client-side handler which allows TPC via unix authentication.
  *     Added to the channel pipeline to handle protocol and auth requests
@@ -49,33 +45,19 @@ import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ok;
  *     pool, which now requires unix (in order to guarantee signed hashes
  *     are passed from the vanilla xrootd client).</p>
  *
- *  <p>The module merely sends a response with the uid + " " + gid; the
+ *  The module merely sends a response with the username; the
  *     sigver handler is given no crypto handler, and thus sigver requests
  *     will be signed without encryption.</p>
  */
-public class UnixClientAuthenticationHandler extends AbstractClientAuthnHandler
-{
+public class UnixClientAuthenticationHandler extends AbstractClientAuthnHandler {
+
     public static final String PROTOCOL = "unix";
 
-    private static String getCredential(XrootdTpcClient client)
-    {
-        Long uid = client.getInfo().getUid();
-
-        if (uid == null) {
-            return PROTOCOL + client.getUname();
-        }
-
-        Long gid = client.getInfo().getGid();
-
-        if (gid == null) {
-            return PROTOCOL + uid;
-        } else {
-            return PROTOCOL + uid + " " + gid;
-        }
+    private static String getCredential(XrootdTpcClient client) {
+        return client.getUname();
     }
 
-    private static void writeBytes(ByteBuf buffer, String cred)
-    {
+    private static void writeBytes(ByteBuf buffer, String cred) {
         byte[] bytes = cred.getBytes(US_ASCII);
         buffer.writeBytes(bytes);
     }
@@ -86,9 +68,8 @@ public class UnixClientAuthenticationHandler extends AbstractClientAuthnHandler
 
     @Override
     protected void doOnAuthenticationResponse(ChannelHandlerContext ctx,
-                                              InboundAuthenticationResponse response)
-                    throws XrootdException
-    {
+          InboundAuthenticationResponse response)
+          throws XrootdException {
         ChannelId id = ctx.channel().id();
         int status = response.getStatus();
         int streamId = client.getStreamId();
@@ -96,51 +77,50 @@ public class UnixClientAuthenticationHandler extends AbstractClientAuthnHandler
         switch (status) {
             case kXR_ok:
                 LOGGER.debug("Authentication to {}, channel {}, stream {}, "
-                                             + "sessionId {} succeeded; "
-                                             + "passing to next handler.",
-                             tpcInfo.getSrc(),
-                             id,
-                             streamId,
-                             client.getSessionId());
+                            + "sessionId {} succeeded; "
+                            + "passing to next handler.",
+                      tpcInfo.getSrc(),
+                      id,
+                      streamId,
+                      client.getSessionId());
                 ctx.fireChannelRead(response);
                 break;
             default:
                 throw new XrootdException(kXR_error, "failed with status "
-                                            + status);
+                      + status);
         }
     }
 
     @Override
-    protected void sendAuthenticationRequest(ChannelHandlerContext ctx)
-    {
+    protected void sendAuthenticationRequest(ChannelHandlerContext ctx) {
         SigningPolicy signingPolicy = client.getSigningPolicy();
         TLSSessionInfo tlsSessionInfo = client.getTlsSessionInfo();
         LOGGER.debug("Getting (optional) signed hash verification encoder, "
-                                     + "signing is on? {}; tls ? {}.",
-                     signingPolicy.isSigningOn(), tlsSessionInfo.getClientTls());
+                    + "signing is on? {}; tls ? {}.",
+              signingPolicy.isSigningOn(), tlsSessionInfo.getClientTls());
         if (signingPolicy.isSigningOn()) {
             /*
              * Insert sigver encoder into pipeline.  Added after the encoder,
              * but for outbound processing, it gets called before the encoder.
              */
             TpcSigverRequestEncoder sigverRequestEncoder =
-                            new TpcSigverRequestEncoder(null, signingPolicy);
+                  new TpcSigverRequestEncoder(null, signingPolicy);
             ctx.pipeline().addAfter("encoder",
-                                    "sigverEncoder",
-                                    sigverRequestEncoder);
+                  "sigverEncoder",
+                  sigverRequestEncoder);
         }
 
         String cred = getCredential(client);
         Consumer<ByteBuf> serializer = b -> writeBytes(b, cred);
         OutboundAuthenticationRequest request
-                        = new OutboundAuthenticationRequest(client.getStreamId(),
-                                                            PROTOCOL,
-                                                            cred.length(),
-                                                            serializer);
+              = new OutboundAuthenticationRequest(client.getStreamId(),
+              PROTOCOL,
+              cred.length(),
+              serializer);
         client.setExpectedResponse(kXR_auth);
         client.setAuthResponse(null);
         ctx.writeAndFlush(request, ctx.newPromise())
-           .addListener(FIRE_EXCEPTION_ON_FAILURE);
+              .addListener(FIRE_EXCEPTION_ON_FAILURE);
         client.startTimer(ctx);
     }
 }


### PR DESCRIPTION
Motivation:

changed the credential sent from 'username' to 'unixUID GID'.
This was based on a slight misunderstanding of the vanilla
server code, on two counts (unix was an actual prefix of
the credential, not prepended to the buffer from the
credential type field; and UID GID in the code actually
stood for user and group ids, not names).

This caused problems for NDGF/Alice upon upgrade to this
version:

```
[ERROR] Server responded with an error: [3010] unix25021 25020 security protocol is not supported.
```

Modification:

Revert the code to what it was doing previously (sending
only the username).

Result:

UNIX protocol interaction (with EOS/xrootd server) should
work again.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Patch: https://rb.dcache.org/r/13201/
Requires-notes: yes
Requires-book: no
Acked-by: Lea
Acked-by: Tigran