### PR TITLE
xrootd4j: unset all tls-require flags when mode is OPTIONAL

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/TLSSessionInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/TLSSessionInfo.java
@@ -3,20 +3,41 @@
  *
  * This file is part of xrootd4j.
  *
- * xrootd4j is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * xrootd4j is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
  *
- * xrootd4j is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * xrootd4j is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with xrootd4j.  If not, see http://www.gnu.org/licenses/.
+ * You should have received a copy of the GNU Lesser General Public License along with xrootd4j.  If
+ * not, see http://www.gnu.org/licenses/.
  */
 package org.dcache.xrootd.security;
+
+import static org.dcache.xrootd.protocol.XrootdProtocol.PROTOCOL_TLS_VERSION;
+import static org.dcache.xrootd.protocol.XrootdProtocol.PROTOCOL_VERSION;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ExpBind;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ExpGPF;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ExpGPFA;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ExpLogin;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ExpNone;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ExpTPC;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ServerError;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_TLSRequired;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ableTLS;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_bind;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_login;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_protocol;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_secreqs;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_wantTLS;
+import static org.dcache.xrootd.security.TLSSessionInfo.TlsActivation.DATA;
+import static org.dcache.xrootd.security.TLSSessionInfo.TlsActivation.LOGIN;
+import static org.dcache.xrootd.security.TLSSessionInfo.TlsActivation.NONE;
+import static org.dcache.xrootd.security.TLSSessionInfo.TlsActivation.TPC;
+import static org.dcache.xrootd.util.ServerProtocolFlags.TlsMode.OFF;
+import static org.dcache.xrootd.util.ServerProtocolFlags.TlsMode.OPTIONAL;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -245,8 +266,23 @@ public class TLSSessionInfo
                 return;
             }
 
-            switch (expect)
-            {
+            /*
+             *  Guarantee consistency, in case the configuration redundantly set one of these flags.
+             */
+            if (serverFlags.getMode() == OPTIONAL) {
+                serverFlags.setRequiresTLSForData(false);
+                serverFlags.setRequiresTLSForSession(false);
+                serverFlags.setRequiresTLSForGPF(false);
+                serverFlags.setRequiresTLSForGPFA(false);
+                serverFlags.setRequiresTLSForLogin(false);
+                serverFlags.setRequiresTLSForSession(false);
+                serverFlags.setRequiresTLSForTPC(false);
+                LOGGER.debug(
+                      "setLocalTlsActivation, server mode is OPTIONAL, flags are turned off.");
+                return;
+            }
+
+            switch (expect) {
                 case kXR_ExpNone:
                     LOGGER.debug("setLocalTlsActivation, no expect flags.");
                     /*


### PR DESCRIPTION
Motivation:

In configuring the pools at FNAL, we followed the
recommended formula given in the Book:

```
pool.mover.xrootd.security.tls.mode = OPTIONAL
pool.mover.xrootd.security.tls.require-login = true
```

However, we 'discovered' (that is, I remembered)
that the require-login (and similarly all the other
'require' properties) send back to the client
their corresponding xrootd protocol flags:

```
            kXR_tlsData    - Data must be sent over a TLS connection.
            kXR_tlsLogin   - Login must use a TLS connection.
            kXR_tlsGPF     - kXR_gpfile must use a TLS connection.
            kXR_tlsGPFA    - anonymous kXR_gpfile must use a TLS connection.
            kXR_tlsSess    - Connection transitions to TLS after login.
            kXR_tlsTPC     - Third party copy must use a TLS connection.
```

thus defeating the "optional" mode that the dCache endpoint
should be running in (which means, only turn on TLS if the
client has indicated it wants it -- usually given by
the URL schema 'xroots' instead of 'xroot').

Modification:

In another patch, the dCache Book will need to be
modified to indicate all such properties will be
ignored if the mode is OPTIONAL.  The instruction
to set 'login' with OPTIONAL was botched
information.

In addition, for safety, we know programmatically
turn off those flags if mode == OPTIONAL, guaranteeing
consistent behavior even if the endpoint has
been misconfigured.

Result:

A configuration mistake (which can be costly in that
it would require restarts everywhere) setting
these properties to true when mode is set to
OPTIONAL is prevented.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Patch: https://rb.dcache.org/r/13229/
Requires-notes: yes
Requires-book:yes
Acked-by: Tigran