### PR TITLE
xrootd4j-unix: restore correct bucket structure to unix request

### DIFF
--- a/xrootd4j-unix/src/main/java/org/dcache/xrootd/plugins/authn/unix/UnixClientAuthenticationHandler.java
+++ b/xrootd4j-unix/src/main/java/org/dcache/xrootd/plugins/authn/unix/UnixClientAuthenticationHandler.java
@@ -1,28 +1,32 @@
 /**
  * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
- *
+ * <p>
  * This file is part of xrootd4j.
- *
- * xrootd4j is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * xrootd4j is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * <p>
+ * xrootd4j is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ * <p>
+ * xrootd4j is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with xrootd4j.  If not, see http://www.gnu.org/licenses/.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License along with xrootd4j.  If
+ * not, see http://www.gnu.org/licenses/.
  */
 package org.dcache.xrootd.plugins.authn.unix;
 
 import static io.netty.channel.ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE;
 import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.dcache.xrootd.core.XrootdEncoder.writeZeroPad;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_auth;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_error;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ok;
+import static org.dcache.xrootd.protocol.messages.LoginResponse.AUTHN_PROTOCOL_TYPE_LEN;
+import static org.dcache.xrootd.security.XrootdSecurityProtocol.BucketType.kXRS_creds;
+import static org.dcache.xrootd.security.XrootdSecurityProtocol.BucketType.kXRS_main;
+import static org.dcache.xrootd.security.XrootdSecurityProtocol.BucketType.kXRS_none;
+import static org.dcache.xrootd.security.XrootdSecurityProtocol.kXGC_cert;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
@@ -39,30 +43,71 @@ import org.dcache.xrootd.tpc.protocol.messages.InboundAuthenticationResponse;
 import org.dcache.xrootd.tpc.protocol.messages.OutboundAuthenticationRequest;
 
 /**
- *  <p>Client-side handler which allows TPC via unix authentication.
- *     Added to the channel pipeline to handle protocol and auth requests
- *     and responses.</p>
+ * <p>Client-side handler which allows TPC via unix authentication.
+ * Added to the channel pipeline to handle protocol and auth requests and responses.</p>
  *
- *  <p>This module is largely in support of authenticating to a dCache
- *     pool, which now requires unix (in order to guarantee signed hashes
- *     are passed from the vanilla xrootd client).</p>
- *
- *  The module merely sends a response with the username; the
- *     sigver handler is given no crypto handler, and thus sigver requests
- *     will be signed without encryption.</p>
+ * <p>This module is largely in support of authenticating to a dCache
+ * pool, which now requires unix (in order to guarantee signed hashes are passed from the vanilla
+ * xrootd client).</p>
+ * <p>
+ * The module merely sends a response with the username; the sigver handler is given no crypto
+ * handler, and thus sigver requests will be signed without encryption.</p>
  */
-public class UnixClientAuthenticationHandler extends AbstractClientAuthnHandler
-{
+public class UnixClientAuthenticationHandler extends AbstractClientAuthnHandler {
+
     public static final String PROTOCOL = "unix";
 
     private static String getCredential(XrootdTpcClient client) {
         return client.getUname();
     }
 
-    private static void writeBytes(ByteBuf buffer, String cred)
-    {
+    /*
+     *  The correct structure of the unix request is as follows:
+     *
+     *  Outbound =  4 + [16 + 4] + data [40 + len]
+     *
+     *  streamId	2
+     *  kXR_auth    2
+     *
+     *  \0		    16
+     *  data len	4	= 12[*] + buffer length
+     *
+     *  protocol	4*
+     *  step		4*
+     *  =========
+     *  code		4	kXRS_main_code
+     *  len		    4	= 12[†] + 4 + 4 + len
+     *  protocol	4†
+     *  step		4†
+     *  ---------
+     *  code	    4	kXRS_creds_code
+     *  len	        4
+     *  cred	    len
+     *  code	    4†	kXRS_none
+     *  =========
+     *  code		4*	kXRS_none
+     */
+    private static void writeBytes(ByteBuf buffer, String cred) {
         byte[] bytes = cred.getBytes(US_ASCII);
+        writeZeroPad(PROTOCOL, buffer, AUTHN_PROTOCOL_TYPE_LEN);
+        buffer.writeInt(kXGC_cert);
+        buffer.writeInt(kXRS_main.getCode());
+        buffer.writeInt(getBufferLength(bytes.length));
+        writeZeroPad(PROTOCOL, buffer, AUTHN_PROTOCOL_TYPE_LEN);
+        buffer.writeInt(kXGC_cert);
+        buffer.writeInt(kXRS_creds.getCode());
+        buffer.writeInt(bytes.length);
         buffer.writeBytes(bytes);
+        buffer.writeInt(kXRS_none.getCode());
+        buffer.writeInt(kXRS_none.getCode());
+    }
+
+    private static int getBufferLength(int credlen) {
+        return 28 + credlen;
+    }
+
+    private static int getCredentialLength(String cred) {
+        return 12 + getBufferLength(cred.getBytes(US_ASCII).length);
     }
 
     public UnixClientAuthenticationHandler() {
@@ -71,9 +116,8 @@ public class UnixClientAuthenticationHandler extends AbstractClientAuthnHandler
 
     @Override
     protected void doOnAuthenticationResponse(ChannelHandlerContext ctx,
-                                              InboundAuthenticationResponse response)
-                    throws XrootdException
-    {
+          InboundAuthenticationResponse response)
+          throws XrootdException {
         ChannelId id = ctx.channel().id();
         int status = response.getStatus();
         int streamId = client.getStreamId();
@@ -81,51 +125,50 @@ public class UnixClientAuthenticationHandler extends AbstractClientAuthnHandler
         switch (status) {
             case kXR_ok:
                 LOGGER.debug("Authentication to {}, channel {}, stream {}, "
-                                             + "sessionId {} succeeded; "
-                                             + "passing to next handler.",
-                             tpcInfo.getSrc(),
-                             id,
-                             streamId,
-                             client.getSessionId());
+                            + "sessionId {} succeeded; "
+                            + "passing to next handler.",
+                      tpcInfo.getSrc(),
+                      id,
+                      streamId,
+                      client.getSessionId());
                 ctx.fireChannelRead(response);
                 break;
             default:
                 throw new XrootdException(kXR_error, "failed with status "
-                                            + status);
+                      + status);
         }
     }
 
     @Override
-    protected void sendAuthenticationRequest(ChannelHandlerContext ctx)
-    {
+    protected void sendAuthenticationRequest(ChannelHandlerContext ctx) {
         SigningPolicy signingPolicy = client.getSigningPolicy();
         TLSSessionInfo tlsSessionInfo = client.getTlsSessionInfo();
         LOGGER.debug("Getting (optional) signed hash verification encoder, "
-                                     + "signing is on? {}; tls ? {}.",
-                     signingPolicy.isSigningOn(), tlsSessionInfo.getClientTls());
+                    + "signing is on? {}; tls ? {}.",
+              signingPolicy.isSigningOn(), tlsSessionInfo.getClientTls());
         if (signingPolicy.isSigningOn()) {
             /*
              * Insert sigver encoder into pipeline.  Added after the encoder,
              * but for outbound processing, it gets called before the encoder.
              */
             TpcSigverRequestEncoder sigverRequestEncoder =
-                            new TpcSigverRequestEncoder(null, signingPolicy);
+                  new TpcSigverRequestEncoder(null, signingPolicy);
             ctx.pipeline().addAfter("encoder",
-                                    "sigverEncoder",
-                                    sigverRequestEncoder);
+                  "sigverEncoder",
+                  sigverRequestEncoder);
         }
 
         String cred = getCredential(client);
         Consumer<ByteBuf> serializer = b -> writeBytes(b, cred);
         OutboundAuthenticationRequest request
-                        = new OutboundAuthenticationRequest(client.getStreamId(),
-                                                            PROTOCOL,
-                                                            cred.length(),
-                                                            serializer);
+              = new OutboundAuthenticationRequest(client.getStreamId(),
+              "",
+              getCredentialLength(cred),
+              serializer);
         client.setExpectedResponse(kXR_auth);
         client.setAuthResponse(null);
         ctx.writeAndFlush(request, ctx.newPromise())
-           .addListener(FIRE_EXCEPTION_ON_FAILURE);
+              .addListener(FIRE_EXCEPTION_ON_FAILURE);
         client.startTimer(ctx);
     }
 }


### PR DESCRIPTION
Modification:

History of the issue:

In order to support scitokens and ZTN, some substantial
refactoring of the security code in xrootd4j was done.
Part of this refactoring moved the bucket classes that
appeared to support the complex structure of GSI handshakes
into the GSI module.  This was also done because it
seemed that the UNIX protocol (after an examination
of the C++ code) could be simplified to send a
single string credential.

https://rb.dcache.org/r/12878/
master@fafd349de08a4f4180b193b1533649f9b658ba75

simplified the request structure for the UNIX
protocol, while

https://rb.dcache.org/r/12895/
master@2a7f3fa5ce8a2dd5a70f15844f5bf19b02a06c5a

thought that uid + gid was the correct credential
form.  Recently, we discovered however that
this was slightly botched, and reverted to
username:

https://rb.dcache.org/r/13201/
master@5460d86945d6c115660aa28248ee09f22ae7b2f7

All of these changes, however, were misinterpretations
which went undiscovered because of inadequate testing
against a vanilla xrootd server using the unix
protocol (as it does as data server running beneath
EOS).   The latter use case began to fail (NDGF/Alice
talking to CERN EOS) after these changes.

It turns out that the more complicated bucket structure
is indeed necessary to retain.

Modification:

Rather than moving a lot of code around, it was deemed
easiest just to restore the nested bucket structure
ad hoc in a single writeBytes method.  The byte
sequence was directly deduced from what we were
previously sending.

A comment is added to the method (the structure
as far as I can see is nowhere explicitly prescribed
in a protocol document).

Result:

TPC between dCache as destination and the xrootd
server as source specifying the UNIX protocol
now succeeds again.

Target: master
Request: 4.2
Request: 4.1
Patch: https://rb.dcache.org/r/13252
Requires-book: no
Requires-notes: yes
Acked-by: Tigran