### PR TITLE
xrootd4j: do not overwrite EndSession messages with stored session

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandler.java
@@ -18,18 +18,27 @@
  */
 package org.dcache.xrootd.core;
 
+import static org.dcache.xrootd.protocol.XrootdProtocol.SESSION_ID_SIZE;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_InvalidRequest;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_NotAuthorized;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ServerError;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_Unsupported;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_auth;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_bind;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_endsess;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_inProgress;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_login;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ping;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_protocol;
+import static org.dcache.xrootd.security.TLSSessionInfo.isTLSOn;
+
 import com.google.common.collect.Maps;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.util.ReferenceCountUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.security.auth.Subject;
-
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-
+import javax.security.auth.Subject;
 import org.dcache.xrootd.plugins.AuthenticationFactory;
 import org.dcache.xrootd.plugins.AuthenticationHandler;
 import org.dcache.xrootd.plugins.InvalidHandlerConfigurationException;
@@ -48,9 +57,8 @@ import org.dcache.xrootd.security.RequiresTLS;
 import org.dcache.xrootd.security.SigningPolicy;
 import org.dcache.xrootd.security.TLSSessionInfo;
 import org.dcache.xrootd.util.UserNameUtils;
-
-import static org.dcache.xrootd.protocol.XrootdProtocol.*;
-import static org.dcache.xrootd.security.TLSSessionInfo.isTLSOn;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Netty handler implementing Xrootd kXR_login, kXR_auth, and kXR_endsess.
@@ -72,6 +80,9 @@ public class XrootdAuthenticationHandler extends ChannelInboundHandlerAdapter
 
     private static final ConcurrentMap<XrootdSessionIdentifier,XrootdSession> _sessions =
         Maps.newConcurrentMap();
+
+    private static final XrootdSessionIdentifier CURRENT_SESSION_PLACEHOLDER =
+          new XrootdSessionIdentifier(new byte[SESSION_ID_SIZE]);
 
     private final AtomicBoolean _isInProgress = new AtomicBoolean(false);
     private final XrootdSessionIdentifier _sessionId = new XrootdSessionIdentifier();
@@ -168,14 +179,12 @@ public class XrootdAuthenticationHandler extends ChannelInboundHandlerAdapter
                     case NO_AUTH:
                         throw new XrootdException(kXR_NotAuthorized, "Authentication required");
                     }
-                    request.setSession(_session);
                     doOnEndSession(ctx, (EndSessionRequest) request);
                 } finally {
                     ReferenceCountUtil.release(request);
                 }
                 break;
             case kXR_bind:
-                request.setSession(_session);
                 if (_tlsSessionInfo != null && _tlsSessionInfo.serverUsesTls()) {
                     boolean isStarted = _tlsSessionInfo.serverTransitionedToTLS(kXR_bind, ctx);
                     _log.debug("kXR_bind, server has now transitioned to tls? {}.", isStarted);
@@ -316,14 +325,24 @@ public class XrootdAuthenticationHandler extends ChannelInboundHandlerAdapter
     private void doOnEndSession(ChannelHandlerContext ctx, EndSessionRequest request)
         throws XrootdException
     {
-        XrootdSession session = _sessions.get(request.getSessionId());
-        if (session == null) {
-            throw new XrootdException(kXR_NotFound, "session not found");
+        XrootdSessionIdentifier id = request.getSessionId();
+        if (id.equals(CURRENT_SESSION_PLACEHOLDER)) {
+            ctx.writeAndFlush(new OkResponse<>(request));
+            ctx.channel().close();
+            return;
         }
-        if (!session.hasOwner(_session.getSubject())) {
-            throw new XrootdException(kXR_NotAuthorized, "not session owner");
+        XrootdSession session = _sessions.get(id);
+        if (session != null) {
+            if (!session.hasOwner(_session.getSubject())) {
+                throw new XrootdException(kXR_NotAuthorized, "not session owner");
+            }
+            session.getChannel().close();
         }
-        session.getChannel().close();
+        /*
+         * If the session is not in the map, it has either been removed on another channel,
+         * or it is unknown.  Either way, the vanilla server just sends back OK,
+         * so we do the same.
+         */
         ctx.writeAndFlush(new OkResponse<>(request));
     }
 


### PR DESCRIPTION
Motivation:

See GitHub Xroot "Session not found"
https://github.com/dCache/dcache/issues/6246

For internal purposes, the authentication handler
has always added the session associated with the
original login to its channel to all other request
messages before processing them or passing them
down the pipeline.  This is so that the sessionId
and associated information would be available,
since this is not always sent with every message
by the client.

However, in the case of EndSession, where the
message is sent with the id, it does not
make sense to clobber it with the stored
session object.

This never got us into trouble before the
changes made to the xrdcp client in 5.0+,
where it is not necessarily the case that
an end session request will be sent on the
same channel (i.e., socket) as the original
login.  When this occurs, it is possible
that the original channel has already been
closed and its session id removed from the
map, resulting in "session not found",
when in fact the session which the client
is trying to close is not the one stored.

Notwithstanding the change in xrootd client
implementation, it still appears that the
overwrite in this case is actually a bug,
given that the EndSession request is
explictly bound to a specific session id.

Modification:

Do not overwrite the message's data structure,
but use the id that is sent.

Handle id = all binary zeros (this session).

Do not raise exception for missing or unknown
session, but just return OK.

Result:

This may not solve this issue entirely (see
testing notes below).   But I would deem
what the code is doing to be a bug nonetheless.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Patch: https://rb.dcache.org/r/13264/
Requires-notes: yes
Requires-book: no
Closes: #6246
Acked-by: Tigran
Acked-by: Paul