### PR TITLE
xrootd4j: update copyright

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+    Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 
     This file is part of xrootd4j.
 

--- a/xrootd4j-authz-archetype/pom.xml
+++ b/xrootd4j-authz-archetype/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+    Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 
     This file is part of xrootd4j.
 

--- a/xrootd4j-authz-archetype/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
+++ b/xrootd4j-authz-archetype/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+    Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 
     This file is part of xrootd4j.
 

--- a/xrootd4j-authz-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/xrootd4j-authz-archetype/src/test/resources/projects/basic/archetype.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+# Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 #
 # This file is part of xrootd4j.
 #

--- a/xrootd4j-channelhandler-archetype/pom.xml
+++ b/xrootd4j-channelhandler-archetype/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+    Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 
     This file is part of xrootd4j.
 

--- a/xrootd4j-channelhandler-archetype/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
+++ b/xrootd4j-channelhandler-archetype/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+    Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 
     This file is part of xrootd4j.
 

--- a/xrootd4j-channelhandler-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/xrootd4j-channelhandler-archetype/src/test/resources/projects/basic/archetype.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+# Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 #
 # This file is part of xrootd4j.
 #

--- a/xrootd4j-gsi/pom.xml
+++ b/xrootd4j-gsi/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+    Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 
     This file is part of xrootd4j.
 

--- a/xrootd4j-gsi/src/main/assembly/plugin.xml
+++ b/xrootd4j-gsi/src/main/assembly/plugin.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+    Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 
     This file is part of xrootd4j.
 

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/CertChainValidatorProvider.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/CertChainValidatorProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/CertUtil.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/CertUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/CredentialLoader.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/CredentialLoader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/DHBufferHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/DHBufferHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/DHSession.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/DHSession.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIAuthenticationFactory.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIAuthenticationFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIAuthenticationHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIAuthenticationProvider.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIBucket.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIBucket.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIBucketContainer.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIBucketContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIBucketContainerBuilder.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIBucketContainerBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIBucketUtils.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIBucketUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationFactory.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationProvider.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIClientRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSICredentialManager.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSICredentialManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIServerRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIServerRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/NestedBucketBuffer.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/NestedBucketBuffer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/RSASession.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/RSASession.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/RawBucket.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/RawBucket.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/StringBucket.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/StringBucket.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/UnsignedIntBucket.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/UnsignedIntBucket.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/post49/GSIPost49ClientRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/post49/GSIPost49ClientRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/post49/GSIPost49ServerRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/post49/GSIPost49ServerRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/pre49/GSIPre49ClientRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/pre49/GSIPre49ClientRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/pre49/GSIPre49ServerRequestHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/pre49/GSIPre49ServerRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-gsi/src/main/resources/default.properties
+++ b/xrootd4j-gsi/src/main/resources/default.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+# Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 #
 # This file is part of xrootd4j.
 #

--- a/xrootd4j-scitokens/pom.xml
+++ b/xrootd4j-scitokens/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+    Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 
     This file is part of xrootd4j.
 

--- a/xrootd4j-scitokens/src/main/java/org/dcache/xrootd/plugins/authz/scitokens/AbstractSciTokenAuthzFactory.java
+++ b/xrootd4j-scitokens/src/main/java/org/dcache/xrootd/plugins/authz/scitokens/AbstractSciTokenAuthzFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-scitokens/src/main/java/org/dcache/xrootd/plugins/authz/scitokens/AbstractSciTokenAuthzProvider.java
+++ b/xrootd4j-scitokens/src/main/java/org/dcache/xrootd/plugins/authz/scitokens/AbstractSciTokenAuthzProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-scitokens/src/main/java/org/dcache/xrootd/plugins/authz/scitokens/XrootdSciTokenAuthzHandler.java
+++ b/xrootd4j-scitokens/src/main/java/org/dcache/xrootd/plugins/authz/scitokens/XrootdSciTokenAuthzHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-standalone/pom.xml
+++ b/xrootd4j-standalone/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+    Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 
     This file is part of xrootd4j.
 

--- a/xrootd4j-standalone/src/main/java/org/dcache/xrootd/standalone/DataServer.java
+++ b/xrootd4j-standalone/src/main/java/org/dcache/xrootd/standalone/DataServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-standalone/src/main/java/org/dcache/xrootd/standalone/DataServerChannelInitializer.java
+++ b/xrootd4j-standalone/src/main/java/org/dcache/xrootd/standalone/DataServerChannelInitializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-standalone/src/main/java/org/dcache/xrootd/standalone/DataServerConfiguration.java
+++ b/xrootd4j-standalone/src/main/java/org/dcache/xrootd/standalone/DataServerConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-standalone/src/main/java/org/dcache/xrootd/standalone/DataServerHandler.java
+++ b/xrootd4j-standalone/src/main/java/org/dcache/xrootd/standalone/DataServerHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-standalone/src/main/java/org/dcache/xrootd/standalone/DataServerOptionParser.java
+++ b/xrootd4j-standalone/src/main/java/org/dcache/xrootd/standalone/DataServerOptionParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-standalone/src/main/resources/logback.xml
+++ b/xrootd4j-standalone/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+    Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 
     This file is part of xrootd4j.
 

--- a/xrootd4j-unix/pom.xml
+++ b/xrootd4j-unix/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+    Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 
     This file is part of xrootd4j.
 

--- a/xrootd4j-unix/src/main/assembly/plugin.xml
+++ b/xrootd4j-unix/src/main/assembly/plugin.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+    Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 
     This file is part of xrootd4j.
 

--- a/xrootd4j-unix/src/main/java/org/dcache/xrootd/plugins/authn/unix/UnixClientAuthenticationFactory.java
+++ b/xrootd4j-unix/src/main/java/org/dcache/xrootd/plugins/authn/unix/UnixClientAuthenticationFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-unix/src/main/java/org/dcache/xrootd/plugins/authn/unix/UnixClientAuthenticationHandler.java
+++ b/xrootd4j-unix/src/main/java/org/dcache/xrootd/plugins/authn/unix/UnixClientAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-unix/src/main/java/org/dcache/xrootd/plugins/authn/unix/UnixClientAuthenticationProvider.java
+++ b/xrootd4j-unix/src/main/java/org/dcache/xrootd/plugins/authn/unix/UnixClientAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-ztn/pom.xml
+++ b/xrootd4j-ztn/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+    Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 
     This file is part of xrootd4j.
 

--- a/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/AbstractZTNAuthenticationFactory.java
+++ b/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/AbstractZTNAuthenticationFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/AbstractZTNAuthenticationHandler.java
+++ b/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/AbstractZTNAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/ZTNClientAuthenticationFactory.java
+++ b/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/ZTNClientAuthenticationFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/ZTNClientAuthenticationHandler.java
+++ b/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/ZTNClientAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/ZTNClientAuthenticationProvider.java
+++ b/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/ZTNClientAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/ZTNCredential.java
+++ b/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/ZTNCredential.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/ZTNCredentialUtils.java
+++ b/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/ZTNCredentialUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j-ztn/src/main/resources/default.properties
+++ b/xrootd4j-ztn/src/main/resources/default.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+# Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 #
 # This file is part of xrootd4j.
 #

--- a/xrootd4j/pom.xml
+++ b/xrootd4j/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+    Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 
     This file is part of xrootd4j.
 

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/AbstractXrootdDecoder.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/AbstractXrootdDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandlerFactory.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandlerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandlerProvider.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandlerProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthorizationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthorizationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthorizationHandlerFactory.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthorizationHandlerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthorizationHandlerProvider.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthorizationHandlerProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdDecoder.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdEncoder.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdEncoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdException.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdHandshakeHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdHandshakeHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdProtocolRequestHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdProtocolRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdRequestHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdSession.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdSession.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdSessionIdentifier.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdSessionIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdSigverDecoder.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdSigverDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/AuthenticationFactory.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/AuthenticationFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/AuthenticationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/AuthenticationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/AuthenticationProvider.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/AuthenticationProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/AuthorizationFactory.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/AuthorizationFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/AuthorizationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/AuthorizationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/AuthorizationProvider.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/AuthorizationProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/ChannelHandlerFactory.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/ChannelHandlerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/ChannelHandlerProvider.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/ChannelHandlerProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/InvalidHandlerConfigurationException.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/InvalidHandlerConfigurationException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/ProxyDelegationClient.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/ProxyDelegationClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/ProxyDelegationClientFactory.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/ProxyDelegationClientFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authn/gsi/SerializableX509Credential.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authn/gsi/SerializableX509Credential.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authn/gsi/X509ProxyDelegationClient.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authn/gsi/X509ProxyDelegationClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authn/none/NoAuthenticationFactory.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authn/none/NoAuthenticationFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authn/none/NoAuthenticationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authn/none/NoAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authn/none/NoAuthenticationProvider.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authn/none/NoAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authz/none/NoAuthorizationFactory.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authz/none/NoAuthorizationFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authz/none/NoAuthorizationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authz/none/NoAuthorizationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authz/none/NoAuthorizationProvider.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authz/none/NoAuthorizationProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/tls/SSLHandlerFactory.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/tls/SSLHandlerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/tls/TLSHandlerProvider.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/tls/TLSHandlerProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/XrootdProtocol.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/XrootdProtocol.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/AbstractXrootdRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/AbstractXrootdRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/AbstractXrootdResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/AbstractXrootdResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/AsyncResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/AsyncResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/AuthenticationRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/AuthenticationRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/AuthenticationResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/AuthenticationResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/AwaitAsyncResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/AwaitAsyncResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/CloseRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/CloseRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/DirListRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/DirListRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/DirListResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/DirListResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/DirListStatResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/DirListStatResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/EndSessionRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/EndSessionRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ErrorResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ErrorResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/GenericReadRequestMessage.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/GenericReadRequestMessage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/LocateRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/LocateRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/LocateResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/LocateResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/LoginRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/LoginRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/LoginResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/LoginResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/MkDirRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/MkDirRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/MvRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/MvRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/OkResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/OkResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/OpenRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/OpenRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/OpenResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/OpenResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/PathRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/PathRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/PrepareRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/PrepareRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ProtocolRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ProtocolRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ProtocolResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ProtocolResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/QueryRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/QueryRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/QueryResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/QueryResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ReadRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ReadRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ReadResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ReadResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ReadVRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ReadVRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ReadVResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ReadVResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/RedirectResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/RedirectResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/RmDirRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/RmDirRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/RmRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/RmRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/SetRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/SetRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/SetResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/SetResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/SigverRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/SigverRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/StatRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/StatRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/StatResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/StatResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/StatxRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/StatxRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/StatxResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/StatxResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/StringResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/StringResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/SyncRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/SyncRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/UnknownRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/UnknownRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/WriteRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/WriteRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/XrootdRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/XrootdRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/XrootdResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/XrootdResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ZeroCopyReadResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ZeroCopyReadResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/BufferDecrypter.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/BufferDecrypter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/BufferEncrypter.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/BufferEncrypter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/RequiresTLS.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/RequiresTLS.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/SecurityInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/SecurityInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/SigningPolicy.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/SigningPolicy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/TLSSessionInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/TLSSessionInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/TokenValidator.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/TokenValidator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/XrootdSecurityProtocol.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/XrootdSecurityProtocol.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/stream/AbstractChunkedReadResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/stream/AbstractChunkedReadResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/stream/AbstractChunkedReadvResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/stream/AbstractChunkedReadvResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/stream/ChunkedFileChannelReadResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/stream/ChunkedFileChannelReadResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/stream/ChunkedFileChannelReadvResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/stream/ChunkedFileChannelReadvResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/stream/ChunkedFileReadvResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/stream/ChunkedFileReadvResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/stream/ChunkedResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/stream/ChunkedResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/stream/ChunkedResponseWriteHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/stream/ChunkedResponseWriteHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientAuthnHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientAuthnHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientRequestHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientSourceHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/AbstractClientSourceHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcClientConnectHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcClientConnectHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcDelayedSyncWriteHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcDelayedSyncWriteHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSigverRequestEncoder.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSigverRequestEncoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSourceReadHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/TpcSourceReadHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/XrootdTpcInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/core/XrootdClientDecoder.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/core/XrootdClientDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/core/XrootdClientEncoder.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/core/XrootdClientEncoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/AbstractInboundWaitResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/AbstractInboundWaitResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/AbstractXrootdInboundResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/AbstractXrootdInboundResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/AbstractXrootdOutboundRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/AbstractXrootdOutboundRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundAttnResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundAttnResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundAuthenticationResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundAuthenticationResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundChecksumResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundChecksumResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundCloseResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundCloseResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundEndSessionResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundEndSessionResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundErrorResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundErrorResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundHandshakeResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundHandshakeResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundLoginResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundLoginResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundOpenReadOnlyResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundOpenReadOnlyResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundProtocolResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundProtocolResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundReadResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundReadResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundRedirectResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundRedirectResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundWaitRespResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundWaitRespResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundWaitResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundWaitResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundAuthenticationRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundAuthenticationRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundChecksumRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundChecksumRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundCloseRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundCloseRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundEndSessionRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundEndSessionRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundHandshakeRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundHandshakeRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundLoginRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundLoginRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundOpenReadOnlyRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundOpenReadOnlyRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundProtocolRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundProtocolRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundReadRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundReadRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundSigverRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/OutboundSigverRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/XrootdInboundResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/XrootdInboundResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/XrootdOutboundRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/XrootdOutboundRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/ByteBuffersProvider.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/ByteBuffersProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/ChecksumInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/ChecksumInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/FileStatus.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/FileStatus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/OpaqueStringParser.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/OpaqueStringParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/ParseException.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/ParseException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/ProxyRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/ProxyRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2019 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/ServerProtocolFlags.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/ServerProtocolFlags.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/TriedRc.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/TriedRc.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/UserNameUtils.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/UserNameUtils.java
@@ -1,6 +1,6 @@
 
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/main/resources/default.properties
+++ b/xrootd4j/src/main/resources/default.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+# Copyright (C) 2011-2022 dCache.org <support@dcache.org>
 #
 # This file is part of xrootd4j.
 #

--- a/xrootd4j/src/test/java/org/dcache/xrootd/protocol/messages/ByteBufBuilder.java
+++ b/xrootd4j/src/test/java/org/dcache/xrootd/protocol/messages/ByteBufBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/test/java/org/dcache/xrootd/protocol/messages/DecoderTest.java
+++ b/xrootd4j/src/test/java/org/dcache/xrootd/protocol/messages/DecoderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/test/java/org/dcache/xrootd/protocol/messages/LoginRequestTest.java
+++ b/xrootd4j/src/test/java/org/dcache/xrootd/protocol/messages/LoginRequestTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/test/java/org/dcache/xrootd/protocol/messages/StatRequestTest.java
+++ b/xrootd4j/src/test/java/org/dcache/xrootd/protocol/messages/StatRequestTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/test/java/org/dcache/xrootd/security/SecurityInfoTest.java
+++ b/xrootd4j/src/test/java/org/dcache/xrootd/security/SecurityInfoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/test/java/org/dcache/xrootd/stream/ChunkedFileChannelReadvResponseTest.java
+++ b/xrootd4j/src/test/java/org/dcache/xrootd/stream/ChunkedFileChannelReadvResponseTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/test/java/org/dcache/xrootd/tpc/XrootdTpcInfoTest.java
+++ b/xrootd4j/src/test/java/org/dcache/xrootd/tpc/XrootdTpcInfoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2021 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/test/java/org/dcache/xrootd/util/OpaqueStringParserTest.java
+++ b/xrootd4j/src/test/java/org/dcache/xrootd/util/OpaqueStringParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2018 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *

--- a/xrootd4j/src/test/java/org/dcache/xrootd/util/UserNameUtilsTest.java
+++ b/xrootd4j/src/test/java/org/dcache/xrootd/util/UserNameUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2020 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *


### PR DESCRIPTION
Move them all to 2022.

Target: master
Patch: https://rb.dcache.org/r/13509/
Request: 4.2
Request: 4.1
Request: 4.0
Acked-by: Lea