### PR TITLE
    xrootd4j: add a WaitReplyResponse

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/WaitRetryResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/WaitRetryResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
+ *
+ * This file is part of xrootd4j.
+ *
+ * xrootd4j is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * xrootd4j is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with xrootd4j.  If
+ * not, see http://www.gnu.org/licenses/.
+ */
+package org.dcache.xrootd.protocol.messages;
+
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_wait;
+
+import io.netty.buffer.ByteBuf;
+
+public class WaitRetryResponse<T extends XrootdRequest> extends AbstractXrootdResponse<T> {
+
+    private final int seconds;
+
+    public WaitRetryResponse(T request, int seconds) {
+        super(request, kXR_wait);
+        this.seconds = seconds;
+    }
+
+    @Override
+    public int getDataLength() {
+        return 4;
+    }
+
+    @Override
+    protected void getBytes(ByteBuf buffer) {
+        buffer.writeInt(seconds);
+    }
+}

--- a/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundWaitResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/tpc/protocol/messages/InboundWaitResponse.java
@@ -21,8 +21,8 @@ package org.dcache.xrootd.tpc.protocol.messages;
 import io.netty.buffer.ByteBuf;
 
 /**
- * <p>Server's prerogative to tell the client to wait up to a
- * certain number of seconds.</p>
+ * Server's prerogative to tell the client to wait up to a
+ * certain number of seconds and then retry.</p>
  */
 public class InboundWaitResponse extends AbstractInboundWaitResponse{
     public InboundWaitResponse(ByteBuf buffer, int requestId) {


### PR DESCRIPTION
    Motivation:

    The xrootd protocol supports two types of wait instructions
    from server to client: kXR_wait, and kXR_waitresp.  The first
    tells the client to wait and retry the request; the second
    says wait for further instructions, or timeout if you don't
    receive them.

    The latter is supported by a specific response class, but
    the former is not, although the corresponding
    client inbound message does exist.

    Modification:

    Add the class.

    Result:

    It is easier now for the server to tell the client to
    wait and retry on its own.  This also helps to
    fix a bug in the door code.

    Target: master
    Patch: https://rb.dcache.org/r/13518/
    Request: 4.2
    Request: 4.1
    Request: 4.0
    Acked-by: Paul