### PR TITLE
xrootd4j: expand info for ErrorResponse logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.jar
 *.war
 *.ear
+.reviewboardrc

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandler.java
@@ -103,7 +103,7 @@ public class XrootdAuthenticationHandler extends XrootdRequestHandler {
                     LOGGER.debug("authenticated, login failed {}: {}.", e.getError(),
                           e.getMessage());
                     sessionHandler.setAuthFailed(ctx);
-                    respond(ctx, withError(req, e.getError(), e.getMessage()));
+                    respond(ctx, withError(ctx, req, e.getError(), e.getMessage()));
                     return null;
                 } finally {
                     ReferenceCountUtil.release(req);

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdRequestHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdRequestHandler.java
@@ -168,12 +168,12 @@ public class XrootdRequestHandler extends ChannelInboundHandlerAdapter {
                 req = null; // Do not release reference
             }
         } catch (XrootdException e) {
-            respond(ctx, withError(req, e.getError(), e.getMessage()));
+            respond(ctx, withError(ctx, req, e.getError(), e.getMessage()));
         } catch (Exception e) {
             _log.error("xrootd server error while processing " + req
                   + " (please report this to support@dcache.org)", e);
             respond(ctx,
-                  withError(req, kXR_ServerError,
+                  withError(ctx, req, kXR_ServerError,
                         String.format("Internal server error (%s)",
                               e.getMessage())));
         } finally {
@@ -235,9 +235,9 @@ public class XrootdRequestHandler extends ChannelInboundHandlerAdapter {
         return new OkResponse<>(req);
     }
 
-    protected <T extends XrootdRequest> ErrorResponse<T> withError(T req, int errorCode,
-          String errMsg) {
-        return new ErrorResponse<>(req, errorCode, errMsg);
+    protected <T extends XrootdRequest> ErrorResponse<T> withError(ChannelHandlerContext ctx, T req,
+          int errorCode, String errMsg) {
+        return new ErrorResponse<>(ctx, req, errorCode, errMsg);
     }
 
     protected ChannelFuture respond(ChannelHandlerContext ctx, Object response) {

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdSigverDecoder.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdSigverDecoder.java
@@ -44,16 +44,14 @@ import org.dcache.xrootd.security.BufferDecrypter;
 import org.dcache.xrootd.security.SigningPolicy;
 
 /**
- * A FrameDecoder decoding xrootd frames into AbstractRequestMessage
- * objects. Provides signed hash verification capabilities.</p>
- *
- * Maintains the last seqno used on this TCP connection, as
- *    well as the last sigver request.  When the next request
- *    arrives, verifies that its hash matches the signature of
- *    the sigver request.  If the protocol requires generalized
- *    encryption (session key), the signature is first decrypted
- *    using the provided module.</p>
- *
+ * A FrameDecoder decoding xrootd frames into AbstractRequestMessage objects. Provides signed hash
+ * verification capabilities.</p>
+ * <p>
+ * Maintains the last seqno used on this TCP connection, as well as the last sigver request.  When
+ * the next request arrives, verifies that its hash matches the signature of the sigver request.  If
+ * the protocol requires generalized encryption (session key), the signature is first decrypted
+ * using the provided module.</p>
+ * <p>
  * Must be substituted for the vanilla message decoder.</p>
  */
 public class XrootdSigverDecoder extends AbstractXrootdDecoder {
@@ -112,9 +110,7 @@ public class XrootdSigverDecoder extends AbstractXrootdDecoder {
                       ctx);
             }
         } catch (XrootdException e) {
-            ErrorResponse<?> response
-                  = new ErrorResponse<>(request,
-                  e.getError(),
+            ErrorResponse<?> response = new ErrorResponse<>(ctx, request, e.getError(),
                   Strings.nullToEmpty(e.getMessage()));
             ctx.writeAndFlush(response)
                   .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
@@ -270,14 +266,11 @@ public class XrootdSigverDecoder extends AbstractXrootdDecoder {
     }
 
     /**
-     *  A signature consists of a SHA-256 hash of
-     *    1. an unsigned 64-bit sequence number,
-     *    2. the request header, and
-     *    3. the request payload,
-     *  in that exact order.
-     *
-     *  In this case, 2 + 3 are given in order by the frame buffer, which
-     *  contains the raw bytes of the request.
+     * A signature consists of a SHA-256 hash of 1. an unsigned 64-bit sequence number, 2. the
+     * request header, and 3. the request payload, in that exact order.
+     * <p>
+     * In this case, 2 + 3 are given in order by the frame buffer, which contains the raw bytes of
+     * the request.
      */
     private byte[] generateHash(long seqno,
           byte[] payload,

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/XrootdProtocol.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/XrootdProtocol.java
@@ -174,6 +174,47 @@ public interface XrootdProtocol {
     int kXR_writev = 3031;
     int kXR_REQFENCE = 3032;
 
+    static String getClientRequest(int code) {
+        switch (code) {
+            case kXR_handshake: return "kXR_handshake";
+            case kXR_auth: return "kXR_auth";
+            case kXR_query: return "kXR_query";
+            case kXR_chmod: return "kXR_chmod";
+            case kXR_close: return "kXR_close";
+            case kXR_dirlist: return "kXR_dirlist";
+            case kXR_gpfile: return "kXR_gpfile";
+            case kXR_protocol: return "kXR_protocol";
+            case kXR_login: return "kXR_login";
+            case kXR_mkdir: return "kXR_mkdir";
+            case kXR_mv: return "kXR_mv";
+            case kXR_open: return "kXR_open";
+            case kXR_ping: return "kXR_ping";
+            case kXR_chkpoint: return "kXR_chkpoint";
+            case kXR_read: return "kXR_read";
+            case kXR_rm: return "kXR_rm";
+            case kXR_rmdir: return "kXR_rmdir";
+            case kXR_sync: return "kXR_sync";
+            case kXR_stat: return "kXR_stat";
+            case kXR_set: return "kXR_set";
+            case kXR_write: return "kXR_write";
+            case kXR_fattr: return "kXR_fattr";
+            case kXR_prepare: return "kXR_prepare";
+            case kXR_statx: return "kXR_statx";
+            case kXR_endsess: return "kXR_endsess";
+            case kXR_bind: return "kXR_bind";
+            case kXR_readv: return "kXR_readv";
+            case kXR_pgwrite: return "kXR_pgwrite";
+            case kXR_locate: return "kXR_locate";
+            case kXR_truncate: return "kXR_truncate";
+            case kXR_sigver: return "kXR_sigver";
+            case kXR_pgread: return "kXR_pgread";
+            case kXR_writev: return "kXR_writev";
+            case kXR_REQFENCE: return "kXR_REQFENCE";
+            default:
+                return "unrecognized client request";
+        }
+    }
+
     /**
      *  _______________________________________________________________________
      *  OPEN MODE FOR A REMOTE FILE
@@ -451,4 +492,45 @@ public interface XrootdProtocol {
     @Deprecated // Kept for compatibility with plugins
     int kXR_FileLockedr = 3003;
 
+    static String getServerError(int code) {
+        switch (code) {
+            case kXR_ArgInvalid: return "kXR_ArgInvalid";
+            case kXR_ArgMissing: return "kXR_ArgMissing";
+            case kXR_ArgTooLong: return "kXR_ArgTooLong";
+            case kXR_FileLocked: return "kXR_FileLocked";
+            case kXR_FileNotOpen: return "kXR_FileNotOpen";
+            case kXR_FSError: return "kXR_FSError";
+            case kXR_InvalidRequest: return "kXR_InvalidRequest";
+            case kXR_IOError: return "kXR_IOError";
+            case kXR_NoMemory: return "kXR_NoMemory";
+            case kXR_NoSpace: return "kXR_NoSpace";
+            case kXR_NotAuthorized: return "kXR_NotAuthorized";
+            case kXR_NotFound: return "kXR_NotFound";
+            case kXR_ServerError: return "kXR_ServerError";
+            case kXR_Unsupported: return "kXR_Unsupported";
+            case kXR_noserver: return "kXR_noserver";
+            case kXR_NotFile: return "kXR_NotFile";
+            case kXR_isDirectory: return "kXR_isDirectory";
+            case kXR_Cancelled: return "kXR_Cancelled";
+            case kXR_ItExists: return "kXR_ItExists";
+            case kXR_ChkSumErr: return "kXR_ChkSumErr";
+            case kXR_inProgress: return "kXR_inProgress";
+            case kXR_overQuota: return "kXR_overQuota";
+            case kXR_SigVerErr: return "kXR_SigVerErr";
+            case kXR_DecryptErr: return "kXR_DecryptErr";
+            case kXR_Overloaded: return "kXR_Overloaded";
+            case kXR_fsReadOnly: return "kXR_fsReadOnly";
+            case kXR_BadPayload: return "kXR_BadPayload";
+            case kXR_AttrNotFound: return "kXR_AttrNotFound";
+            case kXR_TLSRequired: return "kXR_TLSRequired";
+            case kXR_noReplicas: return "kXR_noReplicas";
+            case kXR_AuthFailed: return "kXR_AuthFailed";
+            case kXR_Impossible: return "kXR_Impossible";
+            case kXR_Conflict: return "kXR_Conflict";
+            case kXR_noErrorYet: return "kXR_noErrorYet";
+
+            default:
+                return "unrecognized server error";
+        }
+    }
 }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ErrorResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/ErrorResponse.java
@@ -1,16 +1,16 @@
 /**
  * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
- * 
+ *
  * This file is part of xrootd4j.
- * 
+ *
  * xrootd4j is free software: you can redistribute it and/or modify it under the terms of the GNU
  * Lesser General Public License as published by the Free Software Foundation, either version 3 of
  * the License, or (at your option) any later version.
- * 
+ *
  * xrootd4j is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License along with xrootd4j.  If
  * not, see http://www.gnu.org/licenses/.
  */
@@ -20,6 +20,8 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import com.google.common.base.Strings;
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import org.dcache.xrootd.core.XrootdSession;
 import org.dcache.xrootd.protocol.XrootdProtocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,11 +33,17 @@ public class ErrorResponse<T extends XrootdRequest> extends AbstractXrootdRespon
     private final int errnum;
     private final String errmsg;
 
-    public ErrorResponse(T request, int errnum, String errmsg) {
+    public ErrorResponse(ChannelHandlerContext ctx, T request, int errnum, String errmsg) {
         super(request, XrootdProtocol.kXR_error);
         this.errnum = errnum;
         this.errmsg = Strings.nullToEmpty(errmsg);
-        LOGGER.info("Xrootd-Error-Response: ErrorNr={} ErrorMsg={}", errnum, errmsg);
+        XrootdSession session = request.getSession();
+        int reqId = request.getRequestId();
+        LOGGER.info(
+              "Xrootd-Error-Response: [session {}][connection {}][request {} {}]"
+                    + "(error {}, {}, {}).", session == null ? "?" : session.getSessionIdentifier(),
+              ctx.channel(), reqId, XrootdProtocol.getClientRequest(reqId), errnum,
+              XrootdProtocol.getServerError(errnum), errmsg);
     }
 
     public int getErrorNumber() {


### PR DESCRIPTION
Motivation:

More information about error responses.

Modification:

Add session and channel info and translate request
and error codes for the INFO-level logging of
error responses.

Result:

Perhaps more helpful in understand causes that are
suppressed in the client logging.

Target: master
Request: 4.3
Request: 4.2
Request: 4.1
Request: 4.0
Acked-by: Tigran