### PR TITLE
xrootd4j: expand info for ErrorResponse logging

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandler.java
@@ -214,13 +214,13 @@ public class XrootdAuthenticationHandler extends ChannelInboundHandlerAdapter
             }
         } catch (XrootdException e) {
             ErrorResponse error =
-                new ErrorResponse<>(request, e.getError(), e.getMessage());
+                new ErrorResponse<>(ctx, request, e.getError(), e.getMessage());
             ctx.writeAndFlush(error);
         } catch (RuntimeException e) {
             _log.error("xrootd server error while processing " + msg
                                        + " (please report this to support@dcache.org)", e);
             ErrorResponse error =
-                new ErrorResponse<>(request, kXR_ServerError,
+                new ErrorResponse<>(ctx, request, kXR_ServerError,
                                     String.format("Internal server error (%s)",
                                                   e.getMessage()));
             ctx.writeAndFlush(error);

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdSigverDecoder.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdSigverDecoder.java
@@ -18,15 +18,16 @@
  */
 package org.dcache.xrootd.core;
 
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_DecryptErr;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_SigVerErr;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_write;
+import static org.dcache.xrootd.protocol.messages.SigverRequest.SIGVER_VERSION;
+import static org.dcache.xrootd.security.XrootdSecurityProtocol.kXR_nodata;
+
 import com.google.common.base.Strings;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
-
-import javax.crypto.BadPaddingException;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
-
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
@@ -35,18 +36,14 @@ import java.security.NoSuchProviderException;
 import java.util.Arrays;
 import java.util.Formatter;
 import java.util.List;
-
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
 import org.dcache.xrootd.protocol.messages.ErrorResponse;
 import org.dcache.xrootd.protocol.messages.SigverRequest;
 import org.dcache.xrootd.protocol.messages.XrootdRequest;
 import org.dcache.xrootd.security.BufferDecrypter;
 import org.dcache.xrootd.security.SigningPolicy;
-
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_DecryptErr;
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_SigVerErr;
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_write;
-import static org.dcache.xrootd.protocol.messages.SigverRequest.SIGVER_VERSION;
-import static org.dcache.xrootd.security.XrootdSecurityProtocol.kXR_nodata;
 
 /**
  * <p>A FrameDecoder decoding xrootd frames into AbstractRequestMessage
@@ -121,7 +118,8 @@ public class XrootdSigverDecoder extends AbstractXrootdDecoder
             }
         } catch (XrootdException e) {
             ErrorResponse<?> response
-                            = new ErrorResponse<>(request,
+                            = new ErrorResponse<>(ctx,
+                                                  request,
                                                   e.getError(),
                                                   Strings.nullToEmpty(e.getMessage()));
             ctx.writeAndFlush(response)

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/XrootdProtocol.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/XrootdProtocol.java
@@ -174,6 +174,48 @@ public interface XrootdProtocol {
     int     kXR_writev                  = 3031;
     int     kXR_REQFENCE                = 3032;
 
+    static String getClientRequest(int code) {
+        switch (code) {
+            case kXR_handshake: return "kXR_handshake";
+            case kXR_auth: return "kXR_auth";
+            case kXR_query: return "kXR_query";
+            case kXR_chmod: return "kXR_chmod";
+            case kXR_close: return "kXR_close";
+            case kXR_dirlist: return "kXR_dirlist";
+            case kXR_gpfile: return "kXR_gpfile";
+            case kXR_protocol: return "kXR_protocol";
+            case kXR_login: return "kXR_login";
+            case kXR_mkdir: return "kXR_mkdir";
+            case kXR_mv: return "kXR_mv";
+            case kXR_open: return "kXR_open";
+            case kXR_ping: return "kXR_ping";
+            case kXR_chkpoint: return "kXR_chkpoint";
+            case kXR_read: return "kXR_read";
+            case kXR_rm: return "kXR_rm";
+            case kXR_rmdir: return "kXR_rmdir";
+            case kXR_sync: return "kXR_sync";
+            case kXR_stat: return "kXR_stat";
+            case kXR_set: return "kXR_set";
+            case kXR_write: return "kXR_write";
+            case kXR_fattr: return "kXR_fattr";
+            case kXR_prepare: return "kXR_prepare";
+            case kXR_statx: return "kXR_statx";
+            case kXR_endsess: return "kXR_endsess";
+            case kXR_bind: return "kXR_bind";
+            case kXR_readv: return "kXR_readv";
+            case kXR_pgwrite: return "kXR_pgwrite";
+            case kXR_locate: return "kXR_locate";
+            case kXR_truncate: return "kXR_truncate";
+            case kXR_sigver: return "kXR_sigver";
+            case kXR_pgread: return "kXR_pgread";
+            case kXR_writev: return "kXR_writev";
+            case kXR_REQFENCE: return "kXR_REQFENCE";
+            default:
+                return "unrecognized client request";
+        }
+    }
+
+
     /**
      *  _______________________________________________________________________
      *  OPEN MODE FOR A REMOTE FILE
@@ -449,4 +491,44 @@ public interface XrootdProtocol {
     @Deprecated // Kept for compatibility with plugins
     int     kXR_FileLockedr             = 3003;
 
+    static String getServerError(int code) {
+        switch (code) {
+            case kXR_ArgInvalid: return "kXR_ArgInvalid";
+            case kXR_ArgMissing: return "kXR_ArgMissing";
+            case kXR_ArgTooLong: return "kXR_ArgTooLong";
+            case kXR_FileLocked: return "kXR_FileLocked";
+            case kXR_FileNotOpen: return "kXR_FileNotOpen";
+            case kXR_FSError: return "kXR_FSError";
+            case kXR_InvalidRequest: return "kXR_InvalidRequest";
+            case kXR_IOError: return "kXR_IOError";
+            case kXR_NoMemory: return "kXR_NoMemory";
+            case kXR_NoSpace: return "kXR_NoSpace";
+            case kXR_NotAuthorized: return "kXR_NotAuthorized";
+            case kXR_NotFound: return "kXR_NotFound";
+            case kXR_ServerError: return "kXR_ServerError";
+            case kXR_Unsupported: return "kXR_Unsupported";
+            case kXR_noserver: return "kXR_noserver";
+            case kXR_NotFile: return "kXR_NotFile";
+            case kXR_isDirectory: return "kXR_isDirectory";
+            case kXR_Cancelled: return "kXR_Cancelled";
+            case kXR_ItExists: return "kXR_ItExists";
+            case kXR_ChkSumErr: return "kXR_ChkSumErr";
+            case kXR_inProgress: return "kXR_inProgress";
+            case kXR_overQuota: return "kXR_overQuota";
+            case kXR_SigVerErr: return "kXR_SigVerErr";
+            case kXR_DecryptErr: return "kXR_DecryptErr";
+            case kXR_Overloaded: return "kXR_Overloaded";
+            case kXR_fsReadOnly: return "kXR_fsReadOnly";
+            case kXR_BadPayload: return "kXR_BadPayload";
+            case kXR_AttrNotFound: return "kXR_AttrNotFound";
+            case kXR_TLSRequired: return "kXR_TLSRequired";
+            case kXR_noReplicas: return "kXR_noReplicas";
+            case kXR_AuthFailed: return "kXR_AuthFailed";
+            case kXR_Impossible: return "kXR_Impossible";
+            case kXR_Conflict: return "kXR_Conflict";
+            case kXR_noErrorYet: return "kXR_noErrorYet";
+            default:
+                return "unrecognized server error";
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

More information about error responses.

Modification:

Add session and channel info and translate request
and error codes for the INFO-level logging of
error responses.

Result:

Perhaps more helpful in understand causes that are
suppressed in the client logging.

Target: master
Request: 4.3
Request: 4.2
Request: 4.1
Request: 4.0
Acked-by: Tigran