### PR TITLE
xrootd4j: do not reallocate and copy into new direct buffer on write …

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/WriteRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/WriteRequest.java
@@ -38,8 +38,7 @@ public class WriteRequest extends AbstractXrootdRequest implements ByteBuffersPr
         fhandle = buffer.getInt(4);
         offset = buffer.getLong(8);
         dlen = buffer.getInt(20);
-        data = buffer.alloc().ioBuffer(dlen); // Most likely this will be written to disk
-        buffer.getBytes(24, data);
+        data = buffer.retainedSlice(24, dlen);
     }
 
     public int getFileHandle() {


### PR DESCRIPTION
…request

Motivation:

The decoder for incoming requests uses the default bytebuf
allocator to create the frame buffer; this default prefers
direct memory.   It is thus unnecessary, when receiving
data to be written to disk, to reallocate a direct buffer
(alloc().ioBuffer(...)) and write the data from the frame
buffer to it.

Modification:

Use a retainedSlice to preserve the data portion of the
frame buffer and assign it to the data field.

Result:

This should somewhat optimize write.

No observable change to user.

Target: master
Patch: https://rb.dcache.org/r/13633/
Acked-by: Lea
Acked-by: Dmitry
Request: 4.4
Requires-notes: yes
Requires-book: no