### PR TITLE
xrootd4j: disconnect if maximum frame size is exceeded

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/AbstractXrootdDecoder.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/AbstractXrootdDecoder.java
@@ -80,6 +80,19 @@ public abstract class AbstractXrootdDecoder extends ByteToMessageDecoder {
     protected static final Logger LOGGER =
           LoggerFactory.getLogger(AbstractXrootdDecoder.class);
 
+    /**
+     *   The default XRD_CPCHUNKSIZE is 8 MiB.  This is configurable via
+     *   env variable, but we cannot accept arbitrarily large frame sizes
+     *   (for writes) because a single client could then bring down the pool.
+     *
+     *   The boundary at 16 MiB should be sufficient to guard against this
+     *   IF the number of concurrent movers (the I/O queue for xrootd) on
+     *   the pool is sufficiently throttled.  The limit only really guarantees
+     *   that a single client cannot cause an OOM under normal JVM direct memory
+     *   allocation (128 MiB or greater).
+     */
+    private static final int MAX_FRAME_SIZE = 16 * 1024 * 1024;
+
     protected XrootdRequest getRequest(ByteBuf frame) {
         int requestId = frame.getUnsignedShort(2);
 
@@ -146,7 +159,7 @@ public abstract class AbstractXrootdDecoder extends ByteToMessageDecoder {
         int pos = in.readerIndex();
         int headerFrameLength = in.getInt(pos + 20);
 
-        if (headerFrameLength < 0) {
+        if (headerFrameLength < 0 || headerFrameLength > MAX_FRAME_SIZE) {
             LOGGER.error("Received illegal frame length in xrootd header: {}."
                   + " Closing channel.", headerFrameLength);
             return -1;


### PR DESCRIPTION
Motivation:

see #13639

This is the minimal version for backport to the
stable branches.

It uses a hardcoded maximum frame size and
disconnects if that is exceeded.

The client behavior will be to retry and
then finally give up, issuing a "file not found"
error.

Target:  4.4
Request: 4.3
Request: 4.2
Request: 4.1
Request: 4.0
Requires-notes: yes
Patch: https://rb.dcache.org/r/13647/
Acked-by: Dmitry