### PR TITLE
xrootd4j:  do not release buffer of unconsumed message in Authenticat…

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandler.java
@@ -109,12 +109,8 @@ public class XrootdAuthenticationHandler extends XrootdRequestHandler {
                     ReferenceCountUtil.release(req);
                 }
             default:
-                try {
-                    ctx.fireChannelRead(req);
-                    return null;
-                } finally {
-                    ReferenceCountUtil.release(req);
-                }
+                ctx.fireChannelRead(req);
+                return null;
         }
     }
 


### PR DESCRIPTION
…ionHandler

Motivation:

The XrootdRequestHandler getResponse() method expects subclasses to implement the `doOn...` method in such a way that if the specific request is consumed by the subclass, the response is returned, and is not, `null` is returned.  In the latter case, the handler
passes the request down the chain without releasing its associated ByteBuf.  The subclass should not,
in any event, release the request buffer.

The XrootdAuthenticationHandler violates the constract in the default case of its switch statement.  This has gone undiscovered in the dCache implementation because the XrootdAuthenticationHandler is not
used by itself, but is wrapped by the XrootdSessionHandler, which only passes kXR_auth requests to it, thus avoiding the default.

Modification:

Eliminate the offending release.

Result:

Correct behavior which should allow the XrootdAuthenticationHandler to be inserted independently into the pipeline.

Target: master
Request: 4.5
Request: 4.4
Request: 4.3
Patch: https://rb.dcache.org/r/13722/
Requires-notes: no
Acked-by: Tigran