### PR TITLE
xrootd4j: correct regression in NoAuthenticationProvider

### DIFF
--- a/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIAuthenticationHandler.java
+++ b/xrootd4j-gsi/src/main/java/org/dcache/xrootd/plugins/authn/gsi/GSIAuthenticationHandler.java
@@ -161,6 +161,11 @@ public class GSIAuthenticationHandler implements AuthenticationHandler {
     }
 
     @Override
+    public String getProtocolName() {
+        return PROTOCOL;
+    }
+
+    @Override
     public Subject getSubject() {
         return subject;
     }

--- a/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/AbstractZTNAuthenticationHandler.java
+++ b/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/AbstractZTNAuthenticationHandler.java
@@ -120,6 +120,11 @@ public abstract class AbstractZTNAuthenticationHandler
     }
 
     @Override
+    public String getProtocolName() {
+        return PROTOCOL;
+    }
+
+    @Override
     public Subject getSubject() {
         return subject;
     }

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdAuthenticationHandler.java
@@ -47,22 +47,22 @@ public class XrootdAuthenticationHandler extends XrootdRequestHandler {
     private static final Logger LOGGER =
           LoggerFactory.getLogger(XrootdAuthenticationHandler.class);
 
-    private final String protocol;
     private final ProxyDelegationClient proxyDelegationClient;
     private final AuthenticationHandler authenticationHandler;
 
     private XrootdSessionHandler sessionHandler;
 
-    public XrootdAuthenticationHandler(String protocol,
-          AuthenticationFactory authenticationFactory,
+    /*
+     *  NOTE:  we maintain the now unused first String parameter for backward compatibility.
+     */
+    public XrootdAuthenticationHandler(String name, AuthenticationFactory authenticationFactory,
           ProxyDelegationClient proxyDelegationClient) {
-        this.protocol = protocol;
         this.proxyDelegationClient = proxyDelegationClient;
         authenticationHandler = authenticationFactory.createHandler(proxyDelegationClient);
     }
 
     public String getProtocol() {
-        return protocol;
+        return authenticationHandler.getProtocolName();
     }
 
     public AuthenticationHandler getHandler() {

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/AuthenticationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/AuthenticationHandler.java
@@ -36,10 +36,15 @@ public interface AuthenticationHandler {
           throws XrootdException;
 
     /**
-     * @return the protocol that is implemented by the authentication
+     * @return the full protocol string (xrootd) that is implemented by the authentication
      * handler
      */
     public String getProtocol();
+
+    /**
+     * @return the name of the protocol
+     */
+    public String getProtocolName();
 
     /**
      * Get the subject containing the credentials/principals found

--- a/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authn/none/NoAuthenticationHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/plugins/authn/none/NoAuthenticationHandler.java
@@ -47,6 +47,11 @@ public class NoAuthenticationHandler implements AuthenticationHandler {
     }
 
     @Override
+    public String getProtocolName() {
+        return PROTOCOL;
+    }
+
+    @Override
     public Subject getSubject() {
         return null;
     }


### PR DESCRIPTION
Motivation:

In order to support multi-protocol doors, the
unix protocol must be the last alternative sent
back to the client.

The strategy in dCache was to change the name
of the NoAuth handler to unix, but to continue
to allow gplazma:none to map to it.

Outside of dCache, however, the provider
loaded via SPI needs to know about both
alternative names in order to work, e.g.,
in the standalone server.

Modification:

Have the provider respond to either unix
or none, and change its name to unix.

Result:

The plugin can be loaded successfully
again outside of dCache.

Target: master
Request: 4.5
Request: 4.4
Request: 4.3
Request: 4.2
Patch: https://rb.dcache.org/r/13725/
Acked-by: Tigran