### PR TITLE
xrootd4j:  support kXR_prefname in kXR_locate request

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/LocateResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/LocateResponse.java
@@ -1,27 +1,29 @@
 /**
  * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
- * 
+ *
  * This file is part of xrootd4j.
- * 
+ *
  * xrootd4j is free software: you can redistribute it and/or modify it under the terms of the GNU
  * Lesser General Public License as published by the Free Software Foundation, either version 3 of
  * the License, or (at your option) any later version.
- * 
+ *
  * xrootd4j is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License along with xrootd4j.  If
  * not, see http://www.gnu.org/licenses/.
  */
 package org.dcache.xrootd.protocol.messages;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_prefname;
 
-import com.google.common.base.Joiner;
 import com.google.common.net.InetAddresses;
 import io.netty.buffer.ByteBuf;
 import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.Iterator;
 import org.dcache.xrootd.protocol.XrootdProtocol;
 
 public class LocateResponse extends AbstractXrootdResponse<LocateRequest> {
@@ -29,16 +31,12 @@ public class LocateResponse extends AbstractXrootdResponse<LocateRequest> {
     private final String encoded;
 
     public LocateResponse(LocateRequest request, InfoElement... info) {
-        this(request, encode(info));
+        this(request, encode(request, info));
     }
 
     private LocateResponse(LocateRequest request, String encoded) {
         super(request, XrootdProtocol.kXR_ok);
         this.encoded = encoded;
-    }
-
-    public static String encode(InfoElement[] info) {
-        return Joiner.on(" ").join(info);
     }
 
     @Override
@@ -90,10 +88,33 @@ public class LocateResponse extends AbstractXrootdResponse<LocateRequest> {
             return node.value + access.value + InetAddresses.toUriString(address.getAddress()) + ":"
                   + address.getPort();
         }
+
+        void append(StringBuilder builder, boolean preferName) {
+            builder.append(node.value).append(access.value).append(
+                        preferName ? address.getHostName()
+                              : InetAddresses.toUriString(address.getAddress()))
+                  .append(":").append(address.getPort());
+        }
     }
 
     @Override
     public String toString() {
         return "locate-reponse[" + encoded + "]";
+    }
+
+    private static String encode(LocateRequest request, InfoElement[] info) {
+        boolean prefName = (request.getOptions() & kXR_prefname) == kXR_prefname;
+        StringBuilder builder = new StringBuilder();
+        Iterator<InfoElement> it = Arrays.stream(info).iterator();
+        if (it.hasNext()) {
+            it.next().append(builder, prefName);
+        }
+
+        while (it.hasNext()) {
+            builder.append(" ");
+            it.next().append(builder, prefName);
+        }
+
+        return builder.toString();
     }
 }


### PR DESCRIPTION
Motivation:

See GH xroot –– TLS problem when kXR_locate involved (IP address vs hostname) #6892

The xrdfs client calls kXR_locate before asking for a directory listing. Currently our implementation of doOnLocate simply returns the IP address, without respecting the kXR_prefname option.  This was not a problem prior to TLS.  But since TLS requires the hostname, not the IP address, directory listing fails with the error reported (below).

Modification:

Make the locate response respect the kXR_prefname flag.

Result:

Successful listing with TLS on.

Target: master
Request: 4.5
Request: 4.4
Request: 4.3
Request: 4.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/13800/
Closes: #6892
Acked-by: Tigran
Acked-by: Lea