### PR TITLE
xrootd4j:  fix bug in goToTLS value

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/TLSSessionInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/TLSSessionInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2022 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2023 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -40,6 +40,7 @@ import static org.dcache.xrootd.security.TLSSessionInfo.TlsActivation.NONE;
 import static org.dcache.xrootd.security.TLSSessionInfo.TlsActivation.TPC;
 import static org.dcache.xrootd.util.ServerProtocolFlags.TlsMode.OFF;
 import static org.dcache.xrootd.util.ServerProtocolFlags.TlsMode.OPTIONAL;
+import static org.dcache.xrootd.util.ServerProtocolFlags.TlsMode.STRICT;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -110,6 +111,10 @@ public class TLSSessionInfo
         {
             if (flags.getMode() == OFF) {
                 return NONE;
+            }
+
+            if (flags.getMode() == STRICT) {
+                return LOGIN;
             }
 
             if (flags.requiresTLSForLogin()) {
@@ -405,6 +410,7 @@ public class TLSSessionInfo
             }
 
             if (activate) {
+                serverFlags.setGoToTLS(true);
                 sslHandler = (SslHandler) serverSslHandlerFactory.createHandler();
                 sslHandler.engine().setNeedClientAuth(false);
                 sslHandler.engine().setWantClientAuth(false);


### PR DESCRIPTION
Motivation:

`xrootd.security.tls.mode` should immediately
tell the client to `goToTLS` on the `kXR_protocol` request if the mode is `STRICT`.  This is not
happening because of a small oversight in two
places in the TLS session config.

Modification:

Provide the missing checks and side-effects.

Result:

The difference between `STRICT` and `OPTIONAL`
now behaves as expected.

Target: master
Request: 4.5
Request: 4.4
Request: 4.3
Request: 4.2
Requires-notes: yes (with the subsequent dcache pom.xml update).
Patch: https://rb.dcache.org/r/13851/
Acked-by: Dmitry