### PR TITLE
xrootd4j: fix source TLS check for TPC client

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/util/ServerProtocolFlags.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/util/ServerProtocolFlags.java
@@ -18,6 +18,29 @@
  */
 package org.dcache.xrootd.util;
 
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_DataServer;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_LBalServer;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_anongpf;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_attrMeta;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_attrProxy;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_attrSuper;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_gotoTLS;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_haveTLS;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_isManager;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_isServer;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_supgpf;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_suppgrw;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_supposc;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_tlsData;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_tlsGPF;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_tlsGPFA;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_tlsLogin;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_tlsSess;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_tlsTPC;
+import static org.dcache.xrootd.util.ServerProtocolFlags.TlsMode.OFF;
+import static org.dcache.xrootd.util.ServerProtocolFlags.TlsMode.OPTIONAL;
+import static org.dcache.xrootd.util.ServerProtocolFlags.TlsMode.STRICT;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,14 +90,12 @@ public class ServerProtocolFlags
     public ServerProtocolFlags(int flags)
     {
         this.flags = flags;
-        if (!requiresTLSForData() &&
-                        !requiresTLSForGPF() &&
-                        !requiresTLSForLogin() &&
-                        !requiresTLSForSession() &&
-                        !requiresTLSForTPC()) {
-            mode = OFF;
-        } else {
+        if ((flags & kXR_gotoTLS) == kXR_gotoTLS) {
             mode = STRICT;
+        } else if ((flags & kXR_haveTLS) == kXR_haveTLS) {
+            mode = OPTIONAL;
+        } else {
+            mode = OFF;
         }
     }
 


### PR DESCRIPTION
Motivation:

The changes made in https://rb.dcache.org/r/13229/ silently affected the way the TLS requirements of
the source server are determined for the third-party-client.

Since we no longer require any of those special properties to be set when the mode is STRICT, the client now thinks that the endpoint for the source does not support TLS (because when all those properties are false, the mode is set to NONE, which is now incorrect behavior).

Modification:

Deduce the server mode from the two CGI values
for `kXR_haveTLS` and `kXR_gotoTLS`.

Result:

Correct TPC client behavior regarding the
establishment of a secure connection.

Will require update of the libraries in dCache.

Target: master
Request: 4.5
Request: 4.4
Request: 4.3
Requires-notes: yes
Patch: https://rb.dcache.org/r/13925/
Acked-by: Tigran