### PR TITLE
xrootd4j:  turn off TLS and ZTN for pre-5+ clients

### DIFF
--- a/xrootd4j-scitokens/src/main/java/org/dcache/xrootd/plugins/authz/scitokens/XrootdSciTokenAuthzHandler.java
+++ b/xrootd4j-scitokens/src/main/java/org/dcache/xrootd/plugins/authz/scitokens/XrootdSciTokenAuthzHandler.java
@@ -59,8 +59,7 @@ public class XrootdSciTokenAuthzHandler implements AuthorizationHandler, Require
      * The xroot protocol states that the server can specify supporting
      * different authentication protocols via a list which the client
      * should try in order.  The xrootd4j library allows for the chaining
-     * of multiple such handlers on the Netty pipeline (though currently
-     * dCache only supports one protocol, either GSI or none, at a time).
+     * of multiple such handlers on the Netty pipeline.
      *
      * Authorization, on the other hand, takes place after the authentication
      * phase; the xrootd4j authorization handler assumes that the module it

--- a/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/ZTNCredential.java
+++ b/xrootd4j-ztn/src/main/java/org/dcache/xrootd/plugins/authn/ztn/ZTNCredential.java
@@ -16,6 +16,8 @@
  */
 package org.dcache.xrootd.plugins.authn.ztn;
 
+import static org.dcache.xrootd.security.XrootdSecurityProtocol.ZTN;
+
 /**
  *  According to the xroot ztn protocol, the credential sent on the
  *  request method by the client has this structure:
@@ -29,7 +31,7 @@ package org.dcache.xrootd.plugins.authn.ztn;
  */
 public class ZTNCredential {
 
-    public static final String PROTOCOL = "ztn";
+    public static final String PROTOCOL = ZTN;
 
     private int version;
     private byte opr;

--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdSessionHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdSessionHandler.java
@@ -28,6 +28,7 @@ import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_login;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ping;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_protocol;
 import static org.dcache.xrootd.security.TLSSessionInfo.isTLSOn;
+import static org.dcache.xrootd.security.XrootdSecurityProtocol.ZTN;
 
 import com.google.common.collect.Maps;
 import io.netty.channel.ChannelHandlerContext;
@@ -314,6 +315,7 @@ public class XrootdSessionHandler extends XrootdRequestHandler {
     private String protocolString() {
         String protocols =
               handlerMap.values().stream().map(h -> h.getHandler())
+                    .filter(h-> tlsSessionInfo.serverUsesTls() || !h.getProtocolName().equals(ZTN))
                     .map(AuthenticationHandler::getProtocol)
                     .collect(Collectors.joining());
         LOGGER.debug("protocols: {}.", protocols);

--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/TLSSessionInfo.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/TLSSessionInfo.java
@@ -48,7 +48,6 @@ import io.netty.util.concurrent.FutureListener;
 import org.dcache.xrootd.core.XrootdException;
 import org.dcache.xrootd.plugins.tls.SSLHandlerFactory;
 import org.dcache.xrootd.util.ServerProtocolFlags;
-import org.dcache.xrootd.util.ServerProtocolFlags.TlsMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -205,25 +204,13 @@ public class TLSSessionInfo {
                 LOGGER.debug("Client NOT TLS capable.");
 
                 /*
-                 *  Two cases of failure for non-capable clients.
+                 *  If the client does not support TLS, we turn it off.
+                 *  The login response will check this and if TLS is off, ZTN authentication
+                 *  will not be included as an *authentication* protocol.
                  *
-                 *  (1) the source server mode is strict, not optional;
-                 *
-                 *  (2) this is the destination server,
-                 *      TLS is required for TPC and the client intends
-                 *      to do TPC.
-                 *
-                 *  The latter check cannot be done here, because
-                 *      we do not know the protocol used to connect
-                 *      to the source yet (an opaque data element
-                 *      passed on the first path query).
+                 *  NOTE: Scitoken *authorization* will fail in this case if strict=true,
+                 *        so support of pre-TLS clients requires strict = false.
                  */
-                if (serverFlags.getMode() == TlsMode.STRICT) {
-                    throw new XrootdException(kXR_TLSRequired,
-                          "Server accepts only secure "
-                                + "connections.");
-                }
-
                 serverFlags.setMode(OFF);
                 LOGGER.debug("TLS is OFF.");
                 return;

--- a/xrootd4j/src/main/java/org/dcache/xrootd/security/XrootdSecurityProtocol.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/security/XrootdSecurityProtocol.java
@@ -24,6 +24,7 @@ public interface XrootdSecurityProtocol {
 
     String SEC_PROTOCOL_PREFIX = "P=";
     String AUTHN_PROTOCOL_PREFIX = "&" + SEC_PROTOCOL_PREFIX;
+    String ZTN = "ztn";
 
     /**
      *  _______________________________________________________________________


### PR DESCRIPTION
Motivation:

When setting the dCache door to use TLS=`STRICT`,
we are currently excluding all xrootd
clients prior to version 5.

When doors were not multi-protocol for authentication, this was acceptable, but now that a door can
support both GSI and ZTN, it is desirable to
allow clients through which do not have the TLS
capability, while at the same time enforcing
it for ZTN without requiring the `xroots`
URL protocol to be expressed.

This is perfectly acceptable from the standpoint
of encryption protection since the xrootd
clients which do not support TLS also do
not support either ZTN authentication or
token authorization.

Modification:

Instead of failing the pre-v5 client when
the  server has TLS turned on, simply
turn off TLS on the server.

When the authentication protocols are
loaded during login, do not include
`ZTN` if the server TLS setting is `OFF`.

Result:

Friendlier behavior towards pre-v5 clients
in a multi-protocol door setting.

WILL REQUIRE ANOTHER LIBRARY UPDATE FOR DCACHE.

Target: master
Request: 4.5
Request: 4.4
Request: 4.3
Request: 4.2
Patch: https://rb.dcache.org/r/13939/
Acked-by: Dmitry