### PR TITLE
Add PrepareResponse, fix PrepareRequest

### DIFF
--- a/xrootd4j-standalone/src/main/java/org/dcache/xrootd/standalone/DataServerHandler.java
+++ b/xrootd4j-standalone/src/main/java/org/dcache/xrootd/standalone/DataServerHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2023 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2024 dCache.org <support@dcache.org>
  *
  * This file is part of xrootd4j.
  *
@@ -27,6 +27,7 @@ import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_Qconfig;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_Unsupported;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_isDir;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_isDirectory;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ok;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_other;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_readable;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_writable;
@@ -63,6 +64,7 @@ import org.dcache.xrootd.protocol.messages.OkResponse;
 import org.dcache.xrootd.protocol.messages.OpenRequest;
 import org.dcache.xrootd.protocol.messages.OpenResponse;
 import org.dcache.xrootd.protocol.messages.PrepareRequest;
+import org.dcache.xrootd.protocol.messages.PrepareResponse;
 import org.dcache.xrootd.protocol.messages.QueryRequest;
 import org.dcache.xrootd.protocol.messages.QueryResponse;
 import org.dcache.xrootd.protocol.messages.ReadRequest;
@@ -280,9 +282,9 @@ public class DataServerHandler extends XrootdProtocolRequestHandler {
     }
 
     @Override
-    protected OkResponse<PrepareRequest> doOnPrepare(ChannelHandlerContext ctx,
-          PrepareRequest msg) {
-        return withOk(msg);
+    protected PrepareResponse doOnPrepare(ChannelHandlerContext ctx,
+          PrepareRequest msg) throws XrootdException {
+        return new PrepareResponse(msg, kXR_ok, new byte[0]);
     }
 
     /**

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/PrepareRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/PrepareRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2023 dCache.org <support@dcache.org>
+ * Copyright (C) 2011-2024 dCache.org <support@dcache.org>
  * 
  * This file is part of xrootd4j.
  * 
@@ -38,8 +38,8 @@ public class PrepareRequest extends AbstractXrootdRequest {
     public PrepareRequest(ByteBuf buffer) {
         super(buffer, kXR_prepare);
 
-        options = buffer.getUnsignedShort(4);
-        priority = buffer.getUnsignedShort(5);
+        options = buffer.getByte(4);
+        priority = buffer.getByte(5);
 
         int plen = buffer.getInt(20);
         int end = 24 + plen;

--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/PrepareResponse.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/PrepareResponse.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2011-2024 dCache.org <support@dcache.org>
+ *
+ * This file is part of xrootd4j.
+ *
+ * xrootd4j is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * xrootd4j is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with xrootd4j.  If
+ * not, see http://www.gnu.org/licenses/.
+ */
+package org.dcache.xrootd.protocol.messages;
+
+import io.netty.buffer.ByteBuf;
+
+public class PrepareResponse extends AbstractXrootdResponse<PrepareRequest> {
+
+    byte[] locator;
+
+    public PrepareResponse(PrepareRequest request, int stat, byte[] locator) {
+        super(request, stat);
+        this.locator = locator;
+    }
+
+    @Override
+    public int getDataLength() {
+        return locator.length;
+    }
+
+    @Override
+    protected void getBytes(ByteBuf buffer) {
+        buffer.writeBytes(locator);
+    }
+}


### PR DESCRIPTION
I added a PrepareResponse class, fixed a bug in PrepareRequest (reading 16-bit ints when it should have been 8-bit), changed return type of doOnPrepare().

This is all in support of my implementing an xrootd interface to the Jefferson Lab tape library.