### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
   <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <ssl-kickstart.version>8.2.0</ssl-kickstart.version>
+      <ayza.version>10.0.0</ayza.version>
   </properties>
 
   <scm>
@@ -199,13 +199,13 @@
       </dependency>
       <dependency>
           <groupId>io.github.hakky54</groupId>
-          <artifactId>sslcontext-kickstart</artifactId>
-          <version>${ssl-kickstart.version}</version>
+          <artifactId>ayza</artifactId>
+          <version>${ayza.version}</version>
       </dependency>
       <dependency>
           <groupId>io.github.hakky54</groupId>
-          <artifactId>sslcontext-kickstart-for-pem</artifactId>
-          <version>${ssl-kickstart.version}</version>
+          <artifactId>ayza-for-pem</artifactId>
+          <version>${ayza.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/xrootd4j-standalone/pom.xml
+++ b/xrootd4j-standalone/pom.xml
@@ -62,12 +62,12 @@
     </dependency>
       <dependency>
           <groupId>io.github.hakky54</groupId>
-          <artifactId>sslcontext-kickstart</artifactId>
+          <artifactId>ayza</artifactId>
       </dependency>
 
       <dependency>
           <groupId>io.github.hakky54</groupId>
-          <artifactId>sslcontext-kickstart-for-pem</artifactId>
+          <artifactId>ayza-for-pem</artifactId>
       </dependency>
 
   </dependencies>


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.0

Sorry for the inconvenience