### PR TITLE
lower log level to debug to report unsupported methods

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdRequestHandler.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/core/XrootdRequestHandler.java
@@ -271,7 +271,7 @@ public class XrootdRequestHandler extends ChannelInboundHandlerAdapter {
     protected <T extends XrootdRequest> XrootdResponse<T> unsupported(ChannelHandlerContext ctx,
           T msg)
           throws XrootdException {
-        _log.warn("Unsupported request: " + msg);
+        _log.debug("Unsupported request: " + msg);
         throw new XrootdException(kXR_Unsupported,
               "Request " + msg.getRequestId() + " not supported");
     }


### PR DESCRIPTION
Motivation:
----------

Commit a501b3d removed OK response to xrootd prepare call and replaced it with unsupported. Unfortunately this results in spamming log files wtith warning message that prepare is not supported

Modification:
-------------

Demote warning message to debug

Result:
-------

No warning message seen in dcache log due to unsupported xrootd calls.

Ticket: https://github.com/dCache/dcache/issues/8081 Acked-by:
Target: trunk
Require-book: no
Require-notes: no