### PR TITLE
prepare request/reeponse: minor fixes handling opaque and unifrom naming

### DIFF
--- a/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/PrepareRequest.java
+++ b/xrootd4j/src/main/java/org/dcache/xrootd/protocol/messages/PrepareRequest.java
@@ -1,16 +1,16 @@
 /**
- * Copyright (C) 2011-2024 dCache.org <support@dcache.org>
- * 
+ * Copyright (C) 2011-2026 dCache.org <support@dcache.org>
+ *
  * This file is part of xrootd4j.
- * 
+ *
  * xrootd4j is free software: you can redistribute it and/or modify it under the terms of the GNU
  * Lesser General Public License as published by the Free Software Foundation, either version 3 of
  * the License, or (at your option) any later version.
- * 
+ *
  * xrootd4j is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License along with xrootd4j.  If
  * not, see http://www.gnu.org/licenses/.
  */
@@ -19,6 +19,7 @@ package org.dcache.xrootd.protocol.messages;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_cancel;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_coloc;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_evict;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_fresh;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_noerrs;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_notify;
@@ -33,7 +34,8 @@ public class PrepareRequest extends AbstractXrootdRequest {
 
     private final int options;
     private final int priority;
-    private final String[] plist;
+    private String[] paths;
+    private String[] opaques;
 
     public PrepareRequest(ByteBuf buffer) {
         super(buffer, kXR_prepare);
@@ -44,7 +46,17 @@ public class PrepareRequest extends AbstractXrootdRequest {
         int plen = buffer.getInt(20);
         int end = 24 + plen;
 
-        plist = buffer.toString(24, end - 24, US_ASCII).split("\n");
+        paths = buffer.toString(24, end - 24, US_ASCII).split("\n");
+        opaques = new String[paths.length];
+
+        for (int i = 0; i < paths.length; i++) {
+            String path = paths[i];
+            int pos = path.indexOf('?');
+            if (pos > -1) {
+                paths[i] = path.substring(0, pos);
+                opaques[i] = path.substring(pos + 1);
+            }
+        }
     }
 
     public int getOptions() {
@@ -55,8 +67,16 @@ public class PrepareRequest extends AbstractXrootdRequest {
         return priority;
     }
 
+    public String[] getPaths() {
+        return paths;
+    }
+
     public String[] getPathList() {
-        return plist;
+        return paths;
+    }
+
+    public String[] getOpaques() {
+        return opaques;
     }
 
     public boolean isCancel() {
@@ -87,9 +107,13 @@ public class PrepareRequest extends AbstractXrootdRequest {
         return (getOptions() & kXR_fresh) == kXR_fresh;
     }
 
+    public boolean isEvict() {
+        return (getOptions() & kXR_evict) == kXR_evict;
+    }
+
     @Override
     public String toString() {
         return String.format("prepare[%d,%d,%s]", options, priority,
-              Arrays.toString(plist));
+              Arrays.toString(paths));
     }
 }


### PR DESCRIPTION
Motivaton:
---------

Proper parsing of opaque was not implemented. Naming convention followed XrootD design specification but was different from other request/reponse classes

Modification:
------------

proper opaque parsing, adjusted naming for uniformity

Result:
-------

Classes ready to be used for implementation of "prepare" call in dCache

Target: trunk
Request: 4.6
Acked-by: Tgran
Patch: https://rb.dcache.org/r/14769/
Issue: https://github.com/dCache/dcache/issues/8121
Require-book: no
Require-notes: no